### PR TITLE
Add authenticated API object

### DIFF
--- a/aioflo/__init__.py
+++ b/aioflo/__init__.py
@@ -1,1 +1,2 @@
 """Define the aioflo package."""
+from .api import async_get_api  # noqa

--- a/aioflo/api.py
+++ b/aioflo/api.py
@@ -1,0 +1,91 @@
+"""Define a base client for interacting with Flo."""
+from datetime import datetime
+from typing import Optional
+
+from aiohttp import ClientSession
+from aiohttp.client_exceptions import ClientError
+
+from .errors import RequestError
+
+API_V1_BASE: str = "https://api.meetflo.com/api/v1"
+
+DEFAULT_HEADER_ACCEPT: str = "application/json, text/plain, */*"
+DEFAULT_HEADER_CONTENT_TYPE: str = "application/json;charset=UTF-8"
+DEFAULT_HEADER_HOST: str = "api.meetflo.com"
+DEFAULT_HEADER_ORIGIN: str = "https://user.meetflo.com"
+DEFAULT_HEADER_REFERER: str = "https://user.meetflo.com/login"
+DEFAULT_HEADER_USER_AGENT: str = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"
+)
+
+
+class API:  # pylint: disable=too-few-public-methods
+    """Define the API object."""
+
+    def __init__(self, session: ClientSession, username: str, password: str) -> None:
+        """Initialize."""
+        self._password: str = password
+        self._session: ClientSession = session
+        self._token: Optional[str] = None
+        self._token_expiration: Optional[datetime] = None
+        self._user_id: Optional[str] = None
+        self._username: str = username
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict = None,
+        params: dict = None,
+        json: dict = None,
+    ) -> dict:
+        """Make a request against the API."""
+        if not headers:
+            headers = {}
+        headers.update(
+            {
+                "Accept": DEFAULT_HEADER_ACCEPT,
+                "Content-Type": DEFAULT_HEADER_CONTENT_TYPE,
+                "Host": DEFAULT_HEADER_HOST,
+                "Origin": DEFAULT_HEADER_ORIGIN,
+                "Referer": DEFAULT_HEADER_REFERER,
+                "User-Agent": DEFAULT_HEADER_USER_AGENT,
+            }
+        )
+
+        if self._token:
+            headers["Authorization"] = self._token
+
+        async with self._session.request(
+            method, url, headers=headers, params=params, json=json
+        ) as resp:
+            data: dict = await resp.json(content_type=None)
+            try:
+                resp.raise_for_status()
+                return data
+            except ClientError as err:
+                raise RequestError(f"There was an error while requesting {url}: {err}")
+
+    async def async_authenticate(self) -> None:
+        """Authenticate the user and retrieve an authentication token."""
+        auth_response: dict = await self._request(
+            "post",
+            f"{API_V1_BASE}/users/auth",
+            json={"username": self._username, "password": self._password},
+        )
+
+        self._token = auth_response["token"]
+        self._token_expiration = datetime.fromtimestamp(
+            auth_response["tokenPayload"]["timestamp"]
+            + auth_response["tokenExpiration"]
+        )
+        self._user_id = auth_response["tokenPayload"]["user"]["user_id"]
+
+
+async def async_get_api(session: ClientSession, username: str, password: str) -> API:
+    """Instantiate an authenticated API object."""
+    api = API(session, username, password)
+    await api.async_authenticate()
+    return api

--- a/aioflo/const.py
+++ b/aioflo/const.py
@@ -1,0 +1,2 @@
+"""Define package constants."""
+API_V2_BASE: str = "https://api-gw.meetflo.com/api/v2"

--- a/aioflo/const.py
+++ b/aioflo/const.py
@@ -1,2 +1,0 @@
-"""Define package constants."""
-API_V2_BASE: str = "https://api-gw.meetflo.com/api/v2"

--- a/aioflo/errors.py
+++ b/aioflo/errors.py
@@ -1,0 +1,13 @@
+"""Define package errors."""
+
+
+class FloError(Exception):
+    """Define a base error."""
+
+    pass
+
+
+class RequestError(FloError):
+    """Define an error related to invalid requests."""
+
+    pass

--- a/example.py
+++ b/example.py
@@ -4,13 +4,13 @@ import logging
 
 from aiohttp import ClientSession
 
-from aioflo import async_get_client
-from aioflo.errors import NotionError
+from aioflo import async_get_api
+from aioflo.errors import FloError
 
 _LOGGER = logging.getLogger()
 
-EMAIL = "email@address.com"
-PASSWORD = "password"
+EMAIL = "<EMAIL>"
+PASSWORD = "<PASSWORD>"
 
 
 async def main() -> None:
@@ -18,20 +18,8 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     async with ClientSession() as session:
         try:
-            client = await async_get_client(EMAIL, PASSWORD, session)
-
-            bridges = await client.bridge.async_all()
-            _LOGGER.info("BRIDGES: %s", bridges)
-
-            sensors = await client.sensor.async_all()
-            _LOGGER.info("SENSORS: %s", sensors)
-
-            systems = await client.system.async_all()
-            _LOGGER.info("SYSTEMS: %s", systems)
-
-            tasks = await client.task.async_all()
-            _LOGGER.info("TASKS: %s", tasks)
-        except NotionError as err:
+            api = await async_get_api(session, EMAIL, PASSWORD)
+        except FloError as err:
             _LOGGER.error("There was an error: %s", err)
 
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,0 +1,5 @@
+"""Define constants for use in tests."""
+TEST_EMAIL_ADDRESS = "email@address.com"
+TEST_PASSWORD = "password"
+TEST_TOKEN = "123abc"
+TEST_USER_ID = "12345abcde"

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,22 @@
+"""Define general test fixtures."""
+import time
+
+import pytest
+
+from ..const import TEST_EMAIL_ADDRESS, TEST_TOKEN, TEST_USER_ID
+
+
+@pytest.fixture()
+def auth_success_json():
+    """Define a response to /api/v1/users/auth."""
+    now = round(time.time())
+
+    return {
+        "token": TEST_TOKEN,
+        "tokenPayload": {
+            "user": {"user_id": TEST_USER_ID, "email": TEST_EMAIL_ADDRESS},
+            "timestamp": now,
+        },
+        "tokenExpiration": 86400,
+        "timeNow": now,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,50 @@
+"""Define general tests for the API."""
+# pylint: disable=protected-access,redefined-outer-name,unused-import
+import json
+
+import aiohttp
+import pytest
+
+from aioflo import async_get_api
+from aioflo.errors import RequestError
+
+from .const import TEST_EMAIL_ADDRESS, TEST_PASSWORD, TEST_TOKEN, TEST_USER_ID
+from .fixtures import auth_success_json  # noqa
+
+
+@pytest.mark.asyncio
+async def test_bad_api_call(aresponses, auth_success_json):
+    """Test that an HTTP error raises the correct error."""
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/bad",
+        "get",
+        aresponses.Response(text=None, status=404),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        with pytest.raises(RequestError):
+            await api._request("get", "https://api.meetflo.com/api/v1/bad")
+
+
+@pytest.mark.asyncio
+async def test_get_api(aresponses, auth_success_json):
+    """Test instantiating an authenticated API object."""
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        assert api._token == TEST_TOKEN
+        assert api._user_id == TEST_USER_ID

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,8 @@
 """Define general tests for the API."""
 # pylint: disable=protected-access,redefined-outer-name,unused-import
+from datetime import datetime, timedelta
 import json
+import logging
 
 import aiohttp
 import pytest
@@ -32,6 +34,39 @@ async def test_bad_api_call(aresponses, auth_success_json):
         api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
         with pytest.raises(RequestError):
             await api._request("get", "https://api.meetflo.com/api/v1/bad")
+
+
+@pytest.mark.asyncio
+async def test_expired_api_token(aresponses, auth_success_json, caplog):
+    """Test that auto-renewal of the access token works."""
+    caplog.set_level(logging.INFO)
+
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/random_good_endpoint",
+        "get",
+        aresponses.Response(text=None, status=200),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        print(api._token_expiration)
+        api._token_expiration = datetime.now() - timedelta(days=1)
+        print(api._token_expiration)
+        await api._request("get", "https://api.meetflo.com/api/v1/random_good_endpoint")
+        assert any("Requesting new access token" in e.message for e in caplog.records)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

This PR kicks things off by creating the ability to get an authenticated API object. The object can make requests and will handle re-authentication if the access token expires.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- ~Update `README.md` with any new documentation.~ Waiting for more meat on the bone.
- [x] Add yourself to `AUTHORS.md`.
