### PR TITLE
Add endpoints to get user info

### DIFF
--- a/aioflo/const.py
+++ b/aioflo/const.py
@@ -1,0 +1,2 @@
+"""Define package constants."""
+API_V2_BASE: str = "https://api-gw.meetflo.com/api/v2"

--- a/aioflo/user.py
+++ b/aioflo/user.py
@@ -1,0 +1,31 @@
+"""Define /user endpoints."""
+from typing import Awaitable, Callable
+
+from .const import API_V2_BASE
+
+
+class User:  # pylint: disable=too-few-public-methods
+    """Define an object to handle the endpoints."""
+
+    def __init__(self, request: Callable[..., Awaitable], user_id: str) -> None:
+        """Initialize."""
+        self._request: Callable[..., Awaitable] = request
+        self._user_id: str = user_id
+
+    async def get_info(
+        self, include_alarm_settings: bool = False, include_location_info: bool = False
+    ) -> dict:
+        """Return lots of user account data."""
+        additional_info = []
+        if include_alarm_settings:
+            additional_info.append("alarmSettings")
+        if include_location_info:
+            additional_info.append("locations")
+
+        params = {}
+        if additional_info:
+            params["expand"] = ",".join(additional_info)
+
+        return await self._request(
+            "get", f"{API_V2_BASE}/users/{self._user_id}", params=params
+        )

--- a/aioflo/user.py
+++ b/aioflo/user.py
@@ -15,7 +15,14 @@ class User:  # pylint: disable=too-few-public-methods
     async def get_info(
         self, include_alarm_settings: bool = False, include_location_info: bool = False
     ) -> dict:
-        """Return lots of user account data."""
+        """Return user account data.
+
+        :param include_alarm_settings: Include expanded alarm information
+        :type label: bool
+        :param include_location_info: Include expanded location info
+        :type pin: bool
+        :rtype: dict
+        """
         additional_info = []
         if include_alarm_settings:
             additional_info.append("alarmSettings")

--- a/const.py
+++ b/const.py
@@ -1,0 +1,2 @@
+"""Define package constants."""
+API_V2_BASE: str = "https://api-gw.meetflo.com/api/v2"

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,5 +1,124 @@
 """Define constants for use in tests."""
+TEST_ACCOUNT_ID = "aabbccdd"
+TEST_DEVICE_ID = "98765"
 TEST_EMAIL_ADDRESS = "email@address.com"
+TEST_FIRST_NAME = "Tom"
+TEST_LAST_NAME = "Jones"
+TEST_LOCATION_ID = "mmnnoopp"
 TEST_PASSWORD = "password"
+TEST_PHONE_NUMBER = "+1 123-456-7890"
 TEST_TOKEN = "123abc"
 TEST_USER_ID = "12345abcde"
+
+RESPONSE_USER_INFO_BASE = {
+    "id": TEST_USER_ID,
+    "email": TEST_EMAIL_ADDRESS,
+    "isActive": True,
+    "firstName": TEST_FIRST_NAME,
+    "lastName": TEST_LAST_NAME,
+    "unitSystem": "imperial_us",
+    "phoneMobile": TEST_PHONE_NUMBER,
+    "locale": "en-US",
+    "locations": [{"id": TEST_LOCATION_ID}],
+    "alarmSettings": [],
+    "locationRoles": [{"locationId": TEST_LOCATION_ID, "roles": ["owner"]}],
+    "accountRole": {"accountId": TEST_ACCOUNT_ID, "roles": ["owner"]},
+    "account": {"id": TEST_ACCOUNT_ID},
+    "enabledFeatures": [],
+}
+
+RESPONSE_USER_INFO_EXPAND_ALARM_SETTINGS = {
+    "id": TEST_USER_ID,
+    "email": TEST_EMAIL_ADDRESS,
+    "isActive": True,
+    "firstName": TEST_FIRST_NAME,
+    "lastName": TEST_LAST_NAME,
+    "unitSystem": "imperial_us",
+    "phoneMobile": TEST_PHONE_NUMBER,
+    "locale": "en-US",
+    "locations": [{"id": TEST_LOCATION_ID}],
+    "alarmSettings": [
+        {
+            "deviceId": TEST_DEVICE_ID,
+            "settings": [
+                {"alarmId": 4, "systemMode": "home", "smsEnabled": False},
+                {"alarmId": 5, "systemMode": "away", "smsEnabled": False},
+                {"alarmId": 4, "systemMode": "away", "smsEnabled": False},
+                {"alarmId": 4, "systemMode": "sleep", "smsEnabled": False},
+                {"alarmId": 5, "systemMode": "home", "smsEnabled": False},
+                {"alarmId": 5, "systemMode": "sleep", "smsEnabled": False},
+            ],
+            "floSenseLevel": 5,
+            "smallDripSensitivity": 4,
+        }
+    ],
+    "locationRoles": [{"locationId": TEST_LOCATION_ID, "roles": ["owner"]}],
+    "accountRole": {"accountId": TEST_ACCOUNT_ID, "roles": ["owner"]},
+    "account": {"id": TEST_ACCOUNT_ID},
+    "enabledFeatures": [],
+}
+
+RESPONSE_USER_INFO_EXPAND_LOCATIONS = {
+    "id": TEST_USER_ID,
+    "email": TEST_EMAIL_ADDRESS,
+    "isActive": True,
+    "firstName": TEST_FIRST_NAME,
+    "lastName": TEST_LAST_NAME,
+    "unitSystem": "imperial_us",
+    "phoneMobile": TEST_PHONE_NUMBER,
+    "locale": "en-US",
+    "locations": [
+        {
+            "id": TEST_LOCATION_ID,
+            "users": [{"id": TEST_USER_ID}],
+            "devices": [{"id": TEST_DEVICE_ID, "macAddress": "606405c11e10"}],
+            "userRoles": [{"userId": TEST_USER_ID, "roles": ["owner"]}],
+            "address": "123 Main Stree",
+            "city": "Boston",
+            "state": "MA",
+            "country": "us",
+            "postalCode": "12345",
+            "timezone": "US/Easter",
+            "gallonsPerDayGoal": 240,
+            "occupants": 2,
+            "stories": 2,
+            "isProfileComplete": True,
+            "nickname": "Home",
+            "irrigationSchedule": {"isEnabled": False},
+            "systemMode": {"target": "home"},
+            "locationType": "sfh",
+            "locationSize": "lte_4000_sq_ft",
+            "waterShutoffKnown": "unsure",
+            "indoorAmenities": [],
+            "outdoorAmenities": [],
+            "plumbingAppliances": ["exp_tank"],
+            "notifications": {
+                "pending": {
+                    "infoCount": 0,
+                    "warningCount": 1,
+                    "criticalCount": 0,
+                    "alarmCount": [{"id": 57, "severity": "warning", "count": 1}],
+                }
+            },
+            "areas": {
+                "default": [
+                    {"id": "212cb17e-0251-4b09-8581-77a5742d8ca6", "name": "Attic"},
+                    {"id": "3bd494f1-7008-42d2-939e-064eb47722b6", "name": "Basement"},
+                    {"id": "8cbb1152-232d-4200-a4bd-713fd2d56ba0", "name": "Garage"},
+                    {
+                        "id": "208ad83e-6cde-4c1a-9984-58d97ea80d27",
+                        "name": "Main Floor",
+                    },
+                    {"id": "cf796985-3360-4cbd-a0ca-2d3f69a11880", "name": "Upstairs"},
+                ],
+                "custom": [],
+            },
+            "account": {"id": "34a43bcd-989d-453b-84f1-71d7951b5b04"},
+        }
+    ],
+    "alarmSettings": [],
+    "locationRoles": [{"locationId": TEST_LOCATION_ID, "roles": ["owner"]}],
+    "accountRole": {"accountId": TEST_ACCOUNT_ID, "roles": ["owner"]},
+    "account": {"id": TEST_ACCOUNT_ID},
+    "enabledFeatures": [],
+}

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,66 @@
+"""Define tests for user-related endpoints."""
+# pylint: disable=protected-access,redefined-outer-name,unused-import
+import json
+
+import aiohttp
+import pytest
+
+from aioflo import async_get_api
+
+from .const import (
+    RESPONSE_USER_INFO_BASE,
+    RESPONSE_USER_INFO_EXPAND_ALARM_SETTINGS,
+    TEST_EMAIL_ADDRESS,
+    TEST_PASSWORD,
+)
+from .fixtures import auth_success_json  # noqa
+
+
+@pytest.mark.asyncio
+async def test_get_base_user_info(aresponses, auth_success_json):
+    """Test successfully retrieving the base user info"""
+    user_info_with_alarm_settings = {
+        **RESPONSE_USER_INFO_BASE,
+        **RESPONSE_USER_INFO_EXPAND_ALARM_SETTINGS,
+    }
+
+    user_info_with_locations = {
+        **RESPONSE_USER_INFO_BASE,
+        **RESPONSE_USER_INFO_EXPAND_ALARM_SETTINGS,
+    }
+
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v2/users/12345abcde",
+        "get",
+        aresponses.Response(text=json.dumps(RESPONSE_USER_INFO_BASE), status=200),
+    )
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v2/users/12345abcde",
+        "get",
+        aresponses.Response(text=json.dumps(user_info_with_alarm_settings), status=200),
+    )
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v2/users/12345abcde",
+        "get",
+        aresponses.Response(text=json.dumps(user_info_with_locations), status=200),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        user_info = await api.user.get_info()
+        assert user_info == RESPONSE_USER_INFO_BASE
+
+        user_info = await api.user.get_info(include_alarm_settings=True)
+        assert user_info == user_info_with_alarm_settings
+
+        user_info = await api.user.get_info(include_location_info=True)
+        assert user_info == user_info_with_locations


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the `user` property to the `api` object, which gives access to user endpoints. Right now, there's only one:

* `api.user.get_info`

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- ~Update `README.md` with any new documentation.~ Waiting for more meat on the bone
