### PR TITLE
Add endpoints to get water info

### DIFF
--- a/aioflo/api.py
+++ b/aioflo/api.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 import logging
 from typing import Optional
+from urllib.parse import urlparse
 
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError
@@ -9,6 +10,7 @@ from aiohttp.client_exceptions import ClientError
 from .errors import RequestError
 from .location import Location
 from .user import User
+from .water import Water
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -16,9 +18,8 @@ API_V1_BASE: str = "https://api.meetflo.com/api/v1"
 
 DEFAULT_HEADER_ACCEPT: str = "application/json, text/plain, */*"
 DEFAULT_HEADER_CONTENT_TYPE: str = "application/json;charset=UTF-8"
-DEFAULT_HEADER_HOST: str = "api.meetflo.com"
 DEFAULT_HEADER_ORIGIN: str = "https://user.meetflo.com"
-DEFAULT_HEADER_REFERER: str = "https://user.meetflo.com/login"
+DEFAULT_HEADER_REFERER: str = "https://user.meetflo.com/home"
 DEFAULT_HEADER_USER_AGENT: str = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) "
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"
@@ -38,6 +39,7 @@ class API:  # pylint: disable=too-few-public-methods,too-many-instance-attribute
         self._username: str = username
 
         self.location: Location = Location(self._request)
+        self.water: Water = Water(self._request)
 
         # These endpoints will get instantiated post-authentication:
         self.user: Optional[User] = None
@@ -64,7 +66,7 @@ class API:  # pylint: disable=too-few-public-methods,too-many-instance-attribute
             {
                 "Accept": DEFAULT_HEADER_ACCEPT,
                 "Content-Type": DEFAULT_HEADER_CONTENT_TYPE,
-                "Host": DEFAULT_HEADER_HOST,
+                "Host": urlparse(url).netloc,
                 "Origin": DEFAULT_HEADER_ORIGIN,
                 "Referer": DEFAULT_HEADER_REFERER,
                 "User-Agent": DEFAULT_HEADER_USER_AGENT,

--- a/aioflo/location.py
+++ b/aioflo/location.py
@@ -2,7 +2,7 @@
 from typing import Awaitable, Callable, Optional
 
 from .const import API_V2_BASE
-from .errors import RequestError
+from .util import raise_on_invalid_argument
 
 SYSTEM_MODE_AWAY = "away"
 SYSTEM_MODE_HOME = "home"
@@ -26,8 +26,7 @@ class Location:
         self, location_id: str, mode: str, additional_payload: Optional[dict] = None
     ) -> None:
         """Set the system mode (with optional parameters)."""
-        if mode not in SYSTEM_MODES:
-            raise RequestError(f"Cannot set invalid system mode: {mode}")
+        raise_on_invalid_argument(mode, SYSTEM_MODES)
 
         payload = {"target": "mode"}
         if additional_payload:
@@ -41,6 +40,8 @@ class Location:
     ) -> dict:
         """Return user account data.
 
+        :param location_id: A Flo location UUID
+        :type location_id: ``str``
         :param include_device_info: Include expanded device information
         :type include_device_info: ``bool``
         :rtype: ``dict``
@@ -88,21 +89,8 @@ class Location:
         :param revert_mode: The mode to set after sleep concludes ("away" or "home")
         :type revert_mode: ``str``
         """
-        if revert_minutes not in SLEEP_MINUTE_OPTIONS:
-            raise RequestError(
-                (
-                    f"Cannot set invalid revert duration: {revert_minutes} "
-                    "(valid options: {SLEEP_MINUTE_OPTIONS})"
-                )
-            )
-
-        if revert_mode not in SYSTEM_REVERT_MODES:
-            raise RequestError(
-                (
-                    f"Cannot set invalid revert mode: {revert_mode} "
-                    "(valid options: {SYSTEM_REVERT_MODES})"
-                )
-            )
+        raise_on_invalid_argument(revert_minutes, SLEEP_MINUTE_OPTIONS)
+        raise_on_invalid_argument(revert_mode, SYSTEM_REVERT_MODES)
 
         await self._set_system_mode(
             location_id,

--- a/aioflo/location.py
+++ b/aioflo/location.py
@@ -42,7 +42,7 @@ class Location:
         """Return user account data.
 
         :param include_device_info: Include expanded device information
-        :type label: ``bool``
+        :type include_device_info: ``bool``
         :rtype: ``dict``
         """
         additional_info = []

--- a/aioflo/user.py
+++ b/aioflo/user.py
@@ -18,9 +18,9 @@ class User:  # pylint: disable=too-few-public-methods
         """Return user account data.
 
         :param include_alarm_settings: Include expanded alarm information
-        :type label: ``bool``
+        :type include_alarm_settings: ``bool``
         :param include_location_info: Include expanded location info
-        :type pin: ``bool``
+        :type include_location_info: ``bool``
         :rtype: ``dict``
         """
         additional_info = []

--- a/aioflo/util/__init__.py
+++ b/aioflo/util/__init__.py
@@ -1,0 +1,10 @@
+"""Define general utilities."""
+from ..errors import RequestError
+
+
+def raise_on_invalid_argument(value, options):
+    """Raise a RequestError when an invalid consumption interval is provided."""
+    if value not in options:
+        raise RequestError(
+            f"Invalid keyword argument: {value} (valid options: {options})"
+        )

--- a/aioflo/water.py
+++ b/aioflo/water.py
@@ -1,0 +1,59 @@
+"""Define /water endpoints."""
+from datetime import datetime
+from typing import Awaitable, Callable
+
+from .const import API_V2_BASE
+from .errors import RequestError
+
+CONSUMPTION_INTERVAL_DAILY = "1d"
+CONSUMPTION_INTERVAL_HOURLY = "1h"
+CONSUMPTION_INTERVAL_MONTHLY = "1m"
+CONSUMPTION_INTERVALS = set(
+    [
+        CONSUMPTION_INTERVAL_DAILY,
+        CONSUMPTION_INTERVAL_HOURLY,
+        CONSUMPTION_INTERVAL_MONTHLY,
+    ]
+)
+
+
+class Water:  # pylint: disable=too-few-public-methods
+    """Define an object to handle the endpoints."""
+
+    def __init__(self, request: Callable[..., Awaitable]) -> None:
+        """Initialize."""
+        self._request: Callable[..., Awaitable] = request
+
+    async def get_consumption_info(
+        self,
+        location_id: str,
+        start: datetime,
+        end: datetime,
+        interval: str = CONSUMPTION_INTERVAL_HOURLY,
+    ) -> dict:
+        """Return user account data.
+
+        :param start: The start datetime of the range to examine
+        :type start: ``datetime.datetime``
+        :param end: The end datetime of the range to examine
+        :type end: ``datetime.datetime``
+        :rtype: ``dict``
+        """
+        if interval not in CONSUMPTION_INTERVALS:
+            raise RequestError(
+                (
+                    f"Cannot use invalid duration: {interval} "
+                    "(valid options: {CONSUMPTION_INTERVALS})"
+                )
+            )
+
+        return await self._request(
+            "get",
+            f"{API_V2_BASE}/water/consumption",
+            params={
+                "endDate": end.isoformat(),
+                "interval": interval,
+                "locationId": location_id,
+                "startDate": start.isoformat(),
+            },
+        )

--- a/const.py
+++ b/const.py
@@ -1,2 +1,0 @@
-"""Define package constants."""
-API_V2_BASE: str = "https://api-gw.meetflo.com/api/v2"

--- a/example.py
+++ b/example.py
@@ -1,5 +1,6 @@
 """Run an example script to quickly test."""
 import asyncio
+from datetime import datetime
 import logging
 
 from aiohttp import ClientSession
@@ -9,8 +10,8 @@ from aioflo.errors import FloError
 
 _LOGGER = logging.getLogger()
 
-EMAIL = "<EMAIL>"
-PASSWORD = "<PASSWORD>"
+EMAIL = "jwilhelmy@gmail.com"
+PASSWORD = "Jo3rulez"
 
 
 async def main() -> None:
@@ -26,6 +27,13 @@ async def main() -> None:
             first_location_id = user_info["locations"][0]["id"]
             location_info = await api.location.get_info(first_location_id)
             _LOGGER.info(location_info)
+
+            consumption_info = await api.water.get_consumption_info(
+                first_location_id,
+                datetime(2020, 1, 16, 0, 0),
+                datetime(2020, 1, 16, 23, 59, 59, 999000),
+            )
+            _LOGGER.info(consumption_info)
         except FloError as err:
             _LOGGER.error("There was an error: %s", err)
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -385,3 +385,21 @@ RESPONSE_USER_INFO_EXPAND_LOCATIONS = {
     "account": {"id": TEST_ACCOUNT_ID},
     "enabledFeatures": [],
 }
+
+RESPONSE_WATER_CONSUMPTION_INFO = {
+    "params": {
+        "startDate": "2020-01-16T07:00:00.000Z",
+        "endDate": "2020-01-17T06:59:59.999Z",
+        "interval": "1h",
+        "tz": "US/Mountain",
+        "locationId": TEST_LOCATION_ID,
+    },
+    "aggregations": {"sumTotalGallonsConsumed": 3.674},
+    "items": [
+        {"time": "2020-01-16T00:00:00-07:00", "gallonsConsumed": 0.04},
+        {"time": "2020-01-16T01:00:00-07:00", "gallonsConsumed": 0.477},
+        {"time": "2020-01-16T03:00:00-07:00", "gallonsConsumed": 0.442},
+        {"time": "2020-01-16T07:00:00-07:00", "gallonsConsumed": 1.216},
+        {"time": "2020-01-16T08:00:00-07:00", "gallonsConsumed": 1.499},
+    ],
+}

--- a/tests/const.py
+++ b/tests/const.py
@@ -5,6 +5,7 @@ TEST_EMAIL_ADDRESS = "email@address.com"
 TEST_FIRST_NAME = "Tom"
 TEST_LAST_NAME = "Jones"
 TEST_LOCATION_ID = "mmnnoopp"
+TEST_MAC_ADDRESS = "12:34:56:ab:cd:ef"
 TEST_PASSWORD = "password"
 TEST_PHONE_NUMBER = "+1 123-456-7890"
 TEST_TOKEN = "123abc"
@@ -401,5 +402,35 @@ RESPONSE_WATER_CONSUMPTION_INFO = {
         {"time": "2020-01-16T03:00:00-07:00", "gallonsConsumed": 0.442},
         {"time": "2020-01-16T07:00:00-07:00", "gallonsConsumed": 1.216},
         {"time": "2020-01-16T08:00:00-07:00", "gallonsConsumed": 1.499},
+    ],
+}
+
+RESPONSE_WATER_METRIC_INFO = {
+    "params": {
+        "tz": "US/Mountain",
+        "startDate": "2020-01-16T07:00:00.000Z",
+        "endDate": "2020-01-17T06:59:59.999Z",
+        "macAddress": "606405c11e10",
+        "interval": "1h",
+    },
+    "items": [
+        {
+            "time": "2020-01-16T00:00:00-07:00",
+            "averageGpm": None,
+            "averagePsi": 78.3,
+            "averageTempF": 59.4,
+        },
+        {
+            "time": "2020-01-16T01:00:00-07:00",
+            "averageGpm": None,
+            "averagePsi": 78.2,
+            "averageTempF": 59.8,
+        },
+        {
+            "time": "2020-01-16T02:00:00-07:00",
+            "averageGpm": None,
+            "averagePsi": 77.8,
+            "averageTempF": 61.4,
+        },
     ],
 }

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -33,13 +33,13 @@ async def test_get_location_info(aresponses, auth_success_json):
         aresponses.Response(text=json.dumps(auth_success_json), status=200),
     )
     aresponses.add(
-        "api.meetflo.com",
+        "api-gw.meetflo.com",
         "/api/v2/locations/mmnnoopp",
         "get",
         aresponses.Response(text=json.dumps(RESPONSE_LOCATION_INFO_BASE), status=200),
     )
     aresponses.add(
-        "api.meetflo.com",
+        "api-gw.meetflo.com",
         "/api/v2/locations/mmnnoopp",
         "get",
         aresponses.Response(text=json.dumps(location_info_with_devices), status=200),
@@ -70,19 +70,19 @@ async def test_system_modes(aresponses, auth_success_json):
         aresponses.Response(text=json.dumps(auth_success_json), status=200),
     )
     aresponses.add(
-        "api.meetflo.com",
+        "api-gw.meetflo.com",
         "/api/v2/locations/mmnnoopp/systemMode",
         "post",
         aresponses.Response(text=None, status=204),
     )
     aresponses.add(
-        "api.meetflo.com",
+        "api-gw.meetflo.com",
         "/api/v2/locations/mmnnoopp/systemMode",
         "post",
         aresponses.Response(text=None, status=204),
     )
     aresponses.add(
-        "api.meetflo.com",
+        "api-gw.meetflo.com",
         "/api/v2/locations/mmnnoopp/systemMode",
         "post",
         aresponses.Response(text=None, status=204),

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -36,19 +36,19 @@ async def test_get_user_info(aresponses, auth_success_json):
         aresponses.Response(text=json.dumps(auth_success_json), status=200),
     )
     aresponses.add(
-        "api.meetflo.com",
+        "api-gw.meetflo.com",
         "/api/v2/users/12345abcde",
         "get",
         aresponses.Response(text=json.dumps(RESPONSE_USER_INFO_BASE), status=200),
     )
     aresponses.add(
-        "api.meetflo.com",
+        "api-gw.meetflo.com",
         "/api/v2/users/12345abcde",
         "get",
         aresponses.Response(text=json.dumps(user_info_with_alarm_settings), status=200),
     )
     aresponses.add(
-        "api.meetflo.com",
+        "api-gw.meetflo.com",
         "/api/v2/users/12345abcde",
         "get",
         aresponses.Response(text=json.dumps(user_info_with_locations), status=200),

--- a/tests/test_water.py
+++ b/tests/test_water.py
@@ -36,20 +36,18 @@ async def test_get_consumption_info(aresponses, auth_success_json):
         ),
     )
 
+    start = datetime(2020, 1, 16, 0, 0)
+    end = datetime(2020, 1, 16, 23, 59, 59, 999000)
+
     async with aiohttp.ClientSession() as session:
         api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
         consumption_info = await api.water.get_consumption_info(
-            TEST_LOCATION_ID,
-            datetime(2020, 1, 16, 0, 0),
-            datetime(2020, 1, 16, 23, 59, 59, 999000),
+            TEST_LOCATION_ID, start, end
         )
         assert consumption_info == RESPONSE_WATER_CONSUMPTION_INFO
 
         # Test various cases of using invalid parameter values in set_mode_sleep:
         with pytest.raises(RequestError):
             await api.water.get_consumption_info(
-                TEST_LOCATION_ID,
-                datetime(2020, 1, 16, 0, 0),
-                datetime(2020, 1, 16, 23, 59, 59, 999000),
-                interval="a_totally_fake_interval",
+                TEST_LOCATION_ID, start, end, interval="a_totally_fake_interval",
             )

--- a/tests/test_water.py
+++ b/tests/test_water.py
@@ -11,8 +11,10 @@ from aioflo.errors import RequestError
 
 from .const import (
     RESPONSE_WATER_CONSUMPTION_INFO,
+    RESPONSE_WATER_METRIC_INFO,
     TEST_EMAIL_ADDRESS,
     TEST_LOCATION_ID,
+    TEST_MAC_ADDRESS,
     TEST_PASSWORD,
 )
 from .fixtures import auth_success_json  # noqa
@@ -50,4 +52,35 @@ async def test_get_consumption_info(aresponses, auth_success_json):
         with pytest.raises(RequestError):
             await api.water.get_consumption_info(
                 TEST_LOCATION_ID, start, end, interval="a_totally_fake_interval",
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_metrics(aresponses, auth_success_json):
+    """Test successfully retrieving location info."""
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api-gw.meetflo.com",
+        "/api/v2/water/metrics",
+        "get",
+        aresponses.Response(text=json.dumps(RESPONSE_WATER_METRIC_INFO), status=200),
+    )
+
+    start = datetime(2020, 1, 16, 0, 0)
+    end = datetime(2020, 1, 16, 23, 59, 59, 999000)
+
+    async with aiohttp.ClientSession() as session:
+        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        metrics = await api.water.get_metrics(TEST_MAC_ADDRESS, start, end)
+        assert metrics == RESPONSE_WATER_METRIC_INFO
+
+        # Test various cases of using invalid parameter values in set_mode_sleep:
+        with pytest.raises(RequestError):
+            await api.water.get_metrics(
+                TEST_MAC_ADDRESS, start, end, interval="a_totally_fake_interval",
             )

--- a/tests/test_water.py
+++ b/tests/test_water.py
@@ -1,0 +1,55 @@
+"""Define tests for water-related endpoints."""
+# pylint: disable=protected-access,redefined-outer-name,unused-import
+from datetime import datetime
+import json
+
+import aiohttp
+import pytest
+
+from aioflo import async_get_api
+from aioflo.errors import RequestError
+
+from .const import (
+    RESPONSE_WATER_CONSUMPTION_INFO,
+    TEST_EMAIL_ADDRESS,
+    TEST_LOCATION_ID,
+    TEST_PASSWORD,
+)
+from .fixtures import auth_success_json  # noqa
+
+
+@pytest.mark.asyncio
+async def test_get_consumption_info(aresponses, auth_success_json):
+    """Test successfully retrieving location info."""
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api-gw.meetflo.com",
+        "/api/v2/water/consumption",
+        "get",
+        aresponses.Response(
+            text=json.dumps(RESPONSE_WATER_CONSUMPTION_INFO), status=200
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        consumption_info = await api.water.get_consumption_info(
+            TEST_LOCATION_ID,
+            datetime(2020, 1, 16, 0, 0),
+            datetime(2020, 1, 16, 23, 59, 59, 999000),
+        )
+        assert consumption_info == RESPONSE_WATER_CONSUMPTION_INFO
+
+        # Test various cases of using invalid parameter values in set_mode_sleep:
+        with pytest.raises(RequestError):
+            await api.water.get_consumption_info(
+                TEST_LOCATION_ID,
+                datetime(2020, 1, 16, 0, 0),
+                datetime(2020, 1, 16, 23, 59, 59, 999000),
+                interval="a_totally_fake_interval",
+            )


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the `water` property to the `api` object, which gives access to water endpoints:

* `api.water.get_consumption_info()`
* `api.water.get_metrics()`

Additionally, this PR adds other functions to support these cases and others that already exist.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- ~Update `README.md` with any new documentation.~ Waiting for more meat on the bone
