### PR TITLE
Add endpoints to get alarms

### DIFF
--- a/aioflo/alarm.py
+++ b/aioflo/alarm.py
@@ -1,0 +1,16 @@
+"""Define /alarms endpoints."""
+from typing import Awaitable, Callable
+
+from .const import API_V2_BASE
+
+
+class Alarm:  # pylint: disable=too-few-public-methods
+    """Define an object to handle the endpoints."""
+
+    def __init__(self, request: Callable[..., Awaitable]) -> None:
+        """Initialize."""
+        self._request: Callable[..., Awaitable] = request
+
+    async def get_all(self):
+        """Get all alarms."""
+        return await self._request("get", f"{API_V2_BASE}/alarms")

--- a/aioflo/api.py
+++ b/aioflo/api.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError
 
+from .alarm import Alarm
 from .errors import RequestError
 from .location import Location
 from .user import User
@@ -38,6 +39,7 @@ class API:  # pylint: disable=too-few-public-methods,too-many-instance-attribute
         self._user_id: Optional[str] = None
         self._username: str = username
 
+        self.alarm: Alarm = Alarm(self._request)
         self.location: Location = Location(self._request)
         self.water: Water = Water(self._request)
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -11,6 +11,67 @@ TEST_PHONE_NUMBER = "+1 123-456-7890"
 TEST_TOKEN = "123abc"
 TEST_USER_ID = "12345abcde"
 
+RESPONSE_ALARMS = {
+    "items": [
+        {
+            "id": 3,
+            "name": "health_test_skipped",
+            "displayName": "Health Test Skipped",
+            "description": "Health Test Skipped",
+            "severity": "info",
+            "isInternal": False,
+            "isShutoff": False,
+            "sendWhenValveIsClosed": True,
+            "userActions": {
+                "displayTitle": "Clear this Alert",
+                "displayDescription": "Do you want to ignore this alert if it happens again?",
+                "actions": [],
+            },
+            "actions": [],
+            "supportOptions": [],
+            "active": False,
+            "children": [],
+            "deliveryMedium": {
+                "userConfigurable": False,
+                "sms": {
+                    "supported": True,
+                    "defaultSettings": [
+                        {"systemMode": "home", "enabled": False, "supported": True},
+                        {"systemMode": "away", "enabled": False, "supported": True},
+                        {"systemMode": "sleep", "enabled": False, "supported": True},
+                    ],
+                },
+                "email": {
+                    "supported": True,
+                    "defaultSettings": [
+                        {"systemMode": "home", "enabled": True, "supported": True},
+                        {"systemMode": "away", "enabled": True, "supported": True},
+                        {"systemMode": "sleep", "enabled": True, "supported": True},
+                    ],
+                },
+                "push": {
+                    "supported": True,
+                    "defaultSettings": [
+                        {"systemMode": "home", "enabled": True, "supported": True},
+                        {"systemMode": "away", "enabled": True, "supported": True},
+                        {"systemMode": "sleep", "enabled": True, "supported": True},
+                    ],
+                },
+                "call": {
+                    "supported": False,
+                    "defaultSettings": [
+                        {"systemMode": "home", "enabled": False, "supported": False},
+                        {"systemMode": "away", "enabled": False, "supported": False},
+                        {"systemMode": "sleep", "enabled": False, "supported": False},
+                    ],
+                },
+            },
+            "tags": [],
+            "userFeedbackFlow": [],
+        }
+    ]
+}
+
 RESPONSE_LOCATION_INFO_BASE = {
     "id": TEST_LOCATION_ID,
     "users": [{"id": TEST_USER_ID}],

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -1,0 +1,33 @@
+"""Define tests for alarm-related endpoints."""
+# pylint: disable=protected-access,redefined-outer-name,unused-import
+import json
+
+import aiohttp
+import pytest
+
+from aioflo import async_get_api
+
+from .const import RESPONSE_ALARMS, TEST_EMAIL_ADDRESS, TEST_PASSWORD
+from .fixtures import auth_success_json  # noqa
+
+
+@pytest.mark.asyncio
+async def test_get_user_info(aresponses, auth_success_json):
+    """Test successfully retrieving user info."""
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api-gw.meetflo.com",
+        "/api/v2/alarms",
+        "get",
+        aresponses.Response(text=json.dumps(RESPONSE_ALARMS), status=200),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        alarm_info = await api.alarm.get_all()
+        assert alarm_info == RESPONSE_ALARMS


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the `alarm` property to the `api` object, which gives access to water endpoints:

* `api.alarm.get_all()`

Additionally, this PR adds other functions to support these cases and others that already exist.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- ~Update `README.md` with any new documentation.~ Waiting for more meat on the bone
