### PR TITLE
Add codespell to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,14 @@ repos:
           - --quiet
         language_version: python3
         files: ^((aionotion|tests)/.+)?[^/]+\.py$
+  - repo: https://github.com/codespell-project/codespell
+    rev: v1.16.0
+    hooks:
+      - id: codespell
+        args:
+          - --skip="./.*,*.json"
+          - --quiet-level=2
+        exclude_types: [json]
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:


### PR DESCRIPTION
**Describe what the PR does:**

In my ongoing quest to help submitters with smooth, correct PRs, this PR adds [`codespell`](https://github.com/codespell-project/codespell) as a pre-commit hook.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
