### PR TITLE
Make aiohttp ClientSession optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 💧 aioflo: a Python3, asyncio-friendly library for Notion® Home Monitoring
+# 💧 aioflo: a Python3, asyncio-friendly library for Flo Smart Water Detectors
 
 [![CI](https://github.com/bachya/aioflo/workflows/CI/badge.svg)](https://github.com/bachya/aioflo/actions)
 [![PyPi](https://img.shields.io/pypi/v/aioflo.svg)](https://pypi.python.org/pypi/aioflo)
@@ -27,27 +27,57 @@ pip install aioflo
 
 # Usage
 
-`aioflo` starts within an
-[aiohttp](https://aiohttp.readthedocs.io/en/stable/) `ClientSession`:
-
 ```python
 import asyncio
 
 from aiohttp import ClientSession
 
-from aioflo import Client
+from aioflo import async_get_api
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-        # YOUR CODE HERE
+    """Run!"""
+    api = await async_get_api("<EMAIL>", "<PASSWORD>")
+
+    # Get user account information:
+    user_info = await api.user.get_info()
+    a_location_id = user_info["locations"][0]["id"]
+
+    # Get location (i.e., device) information:
+    location_info = await api.location.get_info(a_location_id)
+
+    # Get consumption info between a start and end datetime:
+    consumption_info = await api.water.get_consumption_info(
+        a_location_id,
+        datetime(2020, 1, 16, 0, 0),
+        datetime(2020, 1, 16, 23, 59, 59, 999000),
+    )
+
+    # Get various other metrics related to water usage:
+    metrics = await api.water.get_metrics(
+        "<DEVICE_MAC_ADDRESS>",
+        datetime(2020, 1, 16, 0, 0),
+        datetime(2020, 1, 16, 23, 59, 59, 999000),
+    )
+
+    # Set the device in "Away" mode:
+    await set_mode_away(a_location_id)
+
+    # Set the device in "Home" mode:
+    await set_mode_home(a_location_id)
+
+    # Set the device in "Sleep" mode for 120 minutes, then return to "Away" mode:
+    await set_mode_sleep(a_location_id, 120, "away")
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())
 ```
 
-Create an API object, initialize it, then get to it:
+By default, library creates a new connection to Flo with each coroutine. If you are
+calling a large number of coroutines (or merely want to squeeze out every second of
+runtime savings possible), an
+[`aiohttp`](https://github.com/aio-libs/aiohttp) `ClientSession` can be used for connection
+pooling:
 
 ```python
 import asyncio
@@ -60,7 +90,7 @@ from aioflo import async_get_api
 async def main() -> None:
     """Create the aiohttp session and run the example."""
     async with ClientSession() as websession:
-        api = await async_get_api(session, "<EMAIL>", "<PASSWORD>")
+        api = await async_get_api("<EMAIL>", "<PASSWORD>", session=session)
 
         # Get user account information:
         user_info = await api.user.get_info()
@@ -92,11 +122,9 @@ async def main() -> None:
         # Set the device in "Sleep" mode for 120 minutes, then return to "Away" mode:
         await set_mode_sleep(a_location_id, 120, "away")
 
-asyncio.get_event_loop().run_until_complete(main())
-```
 
-See the module docstrings throughout the library for full info on all parameters, return
-types, etc.
+asyncio.run(main())
+```
 
 # Contributing
 
@@ -104,7 +132,7 @@ types, etc.
   or [initiate a discussion on one](https://github.com/bachya/aioflo/issues/new).
 2. [Fork the repository](https://github.com/bachya/aioflo/fork).
 3. (_optional, but highly recommended_) Create a virtual environment: `python3 -m venv .venv`
-4. (_optional, but highly recommended_) Enter the virtual environment: `source ./venv/bin/activate`
+4. (_optional, but highly recommended_) Enter the virtual environment: `source ./.venv/bin/activate`
 5. Install the dev environment: `script/setup`
 6. Code your new feature or bug fix.
 7. Write tests that cover your new functionality.

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -10,8 +10,8 @@ from aioflo.errors import FloError
 
 _LOGGER = logging.getLogger()
 
-EMAIL = "jwilhelmy@gmail.com"
-PASSWORD = "Jo3rulez"
+EMAIL = "<EMAIL>"
+PASSWORD = "<PASSWORD>"
 
 
 async def main() -> None:
@@ -19,7 +19,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     async with ClientSession() as session:
         try:
-            api = await async_get_api(session, EMAIL, PASSWORD)
+            api = await async_get_api(EMAIL, PASSWORD, session=session)
 
             user_info = await api.user.get_info()
             _LOGGER.info(user_info)
@@ -38,4 +38,4 @@ async def main() -> None:
             _LOGGER.error("There was an error: %s", err)
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,6 @@ python = "^3.6.0"
 [tool.poetry.dev-dependencies]
 aresponses = "^2.0.0"
 pre-commit = "^2.0.1"
-pytest = "^5.3.5"
+pytest = "^5.4.1"
 pytest-aiohttp = "^0.3.0"
 pytest-cov = "^2.8.1"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,4 @@ aiohttp==3.6.2
 aresponses==1.1.2
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
-pytest==5.3.5
+pytest==5.4.1

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -26,7 +26,29 @@ async def test_get_user_info(aresponses, auth_success_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
         alarm_info = await api.alarm.get_all()
         assert len(alarm_info["items"]) == 1
         assert alarm_info["items"][0]["name"] == "health_test_skipped"
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_no_session(aresponses, auth_success_response):
+    """Test successfully retrieving user info with an auto-generated session."""
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_response), status=200),
+    )
+    aresponses.add(
+        "api-gw.meetflo.com",
+        "/api/v2/alarms",
+        "get",
+        aresponses.Response(text=load_fixture("alarms_response.json"), status=200),
+    )
+
+    api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+    alarm_info = await api.alarm.get_all()
+    assert len(alarm_info["items"]) == 1
+    assert alarm_info["items"][0]["name"] == "health_test_skipped"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,7 +30,7 @@ async def test_bad_api_call(aresponses, auth_success_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
         with pytest.raises(RequestError):
             await api._request("get", "https://api.meetflo.com/api/v1/bad")
 
@@ -60,7 +60,7 @@ async def test_expired_api_token(aresponses, auth_success_response, caplog):
     )
 
     async with aiohttp.ClientSession() as session:
-        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
         print(api._token_expiration)
         api._token_expiration = datetime.now() - timedelta(days=1)
         print(api._token_expiration)
@@ -79,6 +79,6 @@ async def test_get_api(aresponses, auth_success_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
         assert api._token == TEST_TOKEN
         assert api._user_id == TEST_USER_ID

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -37,7 +37,7 @@ async def test_get_location_info(aresponses, auth_success_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
         location_info = await api.location.get_info(TEST_LOCATION_ID)
         assert location_info["address"] == "123 Main Street"
         assert len(location_info["devices"]) == 1
@@ -83,7 +83,7 @@ async def test_system_modes(aresponses, auth_success_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
 
         await api.location.set_mode_away(TEST_LOCATION_ID)
         await api.location.set_mode_home(TEST_LOCATION_ID)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -45,7 +45,7 @@ async def test_get_user_info(aresponses, auth_success_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
         user_info = await api.user.get_info()
         assert user_info["email"] == "email@address.com"
         assert not user_info["alarmSettings"]

--- a/tests/test_water.py
+++ b/tests/test_water.py
@@ -39,7 +39,7 @@ async def test_get_consumption_info(aresponses, auth_success_response):
     end = datetime(2020, 1, 16, 23, 59, 59, 999000)
 
     async with aiohttp.ClientSession() as session:
-        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
         consumption_info = await api.water.get_consumption_info(
             TEST_LOCATION_ID, start, end
         )
@@ -74,7 +74,7 @@ async def test_get_metrics(aresponses, auth_success_response):
     end = datetime(2020, 1, 16, 23, 59, 59, 999000)
 
     async with aiohttp.ClientSession() as session:
-        api = await async_get_api(session, TEST_EMAIL_ADDRESS, TEST_PASSWORD)
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
         metrics = await api.water.get_metrics(TEST_MAC_ADDRESS, start, end)
         assert len(metrics["items"]) == 3
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR makes the `aiohttp` `ClientSession` an optional parameter when creating an API object.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
