### PR TITLE
Add presence endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ async def main() -> None:
     async with ClientSession() as websession:
         api = await async_get_api("<EMAIL>", "<PASSWORD>", session=session)
 
+        # Tell Flo to get updated data from the device
+        ping_response = await api.presence.ping()
+
         # Get user account information:
         user_info = await api.user.get_info()
         a_location_id = user_info["locations"][0]["id"]

--- a/aioflo/api.py
+++ b/aioflo/api.py
@@ -11,6 +11,7 @@ from .alarm import Alarm
 from .device import Device
 from .errors import RequestError
 from .location import Location
+from .presence import Presence
 from .user import User
 from .water import Water
 
@@ -47,6 +48,7 @@ class API:  # pylint: disable=too-few-public-methods,too-many-instance-attribute
         self.location: Location = Location(self._request)
         self.water: Water = Water(self._request)
         self.device: Device = Device(self._request)
+        self.presence: Presence = Presence(self._request)
 
         # These endpoints will get instantiated post-authentication:
         self.user: Optional[User] = None

--- a/aioflo/presence.py
+++ b/aioflo/presence.py
@@ -1,0 +1,16 @@
+"""Define /presence endpoints."""
+from typing import Awaitable, Callable
+
+from .const import API_V2_BASE
+
+
+class Presence:  # pylint: disable=too-few-public-methods
+    """Define an object to handle the endpoints."""
+
+    def __init__(self, request: Callable[..., Awaitable]) -> None:
+        """Initialize."""
+        self._request: Callable[..., Awaitable] = request
+
+    async def ping(self) -> dict:
+        """Send a presence ping to Flo."""
+        return await self._request("post", f"{API_V2_BASE}/presence/me")

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -48,6 +48,9 @@ async def main() -> None:
             open_valve_response = await api.device.open_valve(first_device_id)
             _LOGGER.info(open_valve_response)
 
+            ping_response = await api.presence.ping()
+            _LOGGER.info(ping_response)
+
         except FloError as err:
             _LOGGER.error("There was an error: %s", err)
 

--- a/tests/fixtures/ping_response.json
+++ b/tests/fixtures/ping_response.json
@@ -1,0 +1,8 @@
+{
+  "ipAddress": "11.111.111.111",
+  "userId": "12345abcde",
+  "action": "report",
+  "type": "user",
+  "appName": "legacy",
+  "userData": { "account": { "type": "personal" } }
+}

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -1,0 +1,36 @@
+"""Define tests for user-related endpoints."""
+import json
+
+import aiohttp
+import pytest
+
+from aioflo import async_get_api
+
+from .common import TEST_EMAIL_ADDRESS, TEST_PASSWORD, load_fixture
+
+
+@pytest.mark.asyncio
+async def test_ping(aresponses, auth_success_response):
+    """Test successfully retrieving user info."""
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_response), status=200),
+    )
+    aresponses.add(
+        "api-gw.meetflo.com",
+        "/api/v2/presence/me",
+        "post",
+        aresponses.Response(text=load_fixture("ping_response.json"), status=200),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
+        ping_response = await api.presence.ping()
+        assert ping_response["ipAddress"] == "11.111.111.111"
+        assert ping_response["userId"] == "12345abcde"
+        assert ping_response["action"] == "report"
+        assert ping_response["type"] == "user"
+        assert ping_response["appName"] == "legacy"
+        assert ping_response["userData"]["account"]["type"] == "personal"


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the presence endpoint to the library. This endpoint needs to be called periodically to ensure that other calls return current data. After this is released a small PR to the Flo integration in HA will fix this: https://github.com/home-assistant/core/issues/54712. I have tested both locally and confirmed the functionality. 

**Does this fix a specific issue?**

Not in this library
  
**Checklist:**

- [X] Confirm that one or more new tests are written for the new functionality.
- [X] Run tests and ensure everything passes (with 100% test coverage).
- [X] Update `README.md` with any new documentation.
- [X] Add yourself to `AUTHORS.md`.
