### PR TITLE
Add optional device_mac_address parameter to get_consumption_info

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.11"
           architecture: x64
 
       - run: |
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.11"
           architecture: x64
 
       - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,8 @@ repos:
           - --quiet
           - --format=custom
           - --configfile=.bandit.yaml
+        additional_dependencies:
+          - pbr
         files: ^aioflo/.+\.py$
   - repo: https://github.com/python/black
     rev: 22.10.0
@@ -26,7 +28,7 @@ repos:
           - --skip="./.*,*.json"
           - --quiet-level=4
         exclude_types: [json]
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:
       - id: flake8
@@ -36,7 +38,7 @@ repos:
           - pydocstyle
         files: ^aioflo/.+\.py$
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
         additional_dependencies:

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,3 +4,7 @@
 
 - Aaron Bach (https://github.com/bachya)
 - Dave Mulcahey (https://github.com/dmulcahey)
+
+## Contributors
+
+- Brad Kollmyer (https://github.com/BradKollmyer)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ pip install aioflo
 
 ```python
 import asyncio
+from datetime import datetime
 
 from aiohttp import ClientSession
 
@@ -49,7 +50,8 @@ async def main() -> None:
     location_info = await api.location.get_info(a_location_id)
 
     # Get device information
-    first_device_id = location_info["devices"][0]["id"]
+    first_device = location_info["devices"][0]
+    first_device_id = first_device["id"]
     device_info = await api.device.get_info(first_device_id)
 
     # Run a health test
@@ -61,16 +63,25 @@ async def main() -> None:
     # Open the shutoff valve
     open_valve_response = await api.device.open_valve(first_device_id)
 
-    # Get consumption info between a start and end datetime:
+    # Get consumption info between a start and end datetime (location-wide aggregate):
     consumption_info = await api.water.get_consumption_info(
         a_location_id,
         datetime(2020, 1, 16, 0, 0),
         datetime(2020, 1, 16, 23, 59, 59, 999000),
     )
 
+    # Scope consumption to a single device. Pass device_mac_address when a location
+    # has multiple Flo devices; omit it for the location-wide total:
+    device_consumption = await api.water.get_consumption_info(
+        a_location_id,
+        datetime(2020, 1, 16, 0, 0),
+        datetime(2020, 1, 16, 23, 59, 59, 999000),
+        device_mac_address=first_device["macAddress"],
+    )
+
     # Get various other metrics related to water usage:
     metrics = await api.water.get_metrics(
-        "<DEVICE_MAC_ADDRESS>",
+        first_device["macAddress"],
         datetime(2020, 1, 16, 0, 0),
         datetime(2020, 1, 16, 23, 59, 59, 999000),
     )
@@ -96,6 +107,7 @@ pooling:
 
 ```python
 import asyncio
+from datetime import datetime
 
 from aiohttp import ClientSession
 
@@ -104,7 +116,7 @@ from aioflo import async_get_api
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
+    async with ClientSession() as session:
         api = await async_get_api("<EMAIL>", "<PASSWORD>", session=session)
 
         # Tell Flo to get updated data from the device
@@ -118,7 +130,8 @@ async def main() -> None:
         location_info = await api.location.get_info(a_location_id)
 
         # Get device information
-        first_device_id = location_info["devices"][0]["id"]
+        first_device = location_info["devices"][0]
+        first_device_id = first_device["id"]
         device_info = await api.device.get_info(first_device_id)
 
         # Run a health test
@@ -130,16 +143,25 @@ async def main() -> None:
         # Open the shutoff valve
         open_valve_response = await api.device.open_valve(first_device_id)
 
-        # Get consumption info between a start and end datetime:
+        # Get consumption info between a start and end datetime (location-wide aggregate):
         consumption_info = await api.water.get_consumption_info(
             a_location_id,
             datetime(2020, 1, 16, 0, 0),
             datetime(2020, 1, 16, 23, 59, 59, 999000),
         )
 
+        # Scope consumption to a single device. Pass device_mac_address when a location
+        # has multiple Flo devices; omit it for the location-wide total:
+        device_consumption = await api.water.get_consumption_info(
+            a_location_id,
+            datetime(2020, 1, 16, 0, 0),
+            datetime(2020, 1, 16, 23, 59, 59, 999000),
+            device_mac_address=first_device["macAddress"],
+        )
+
         # Get various other metrics related to water usage:
         metrics = await api.water.get_metrics(
-            "<DEVICE_MAC_ADDRESS>",
+            first_device["macAddress"],
             datetime(2020, 1, 16, 0, 0),
             datetime(2020, 1, 16, 23, 59, 59, 999000),
         )

--- a/aioflo/api.py
+++ b/aioflo/api.py
@@ -91,8 +91,8 @@ class API:  # pylint: disable=too-few-public-methods,too-many-instance-attribute
 
         try:
             async with session.request(method, url, **kwargs) as resp:
-                data: dict = await resp.json(content_type=None)
                 resp.raise_for_status()
+                data: dict = await resp.json(content_type=None)
                 return data
         except ClientError as err:
             raise RequestError(f"There was an error while requesting {url}") from err

--- a/aioflo/water.py
+++ b/aioflo/water.py
@@ -1,6 +1,6 @@
 """Define /water endpoints."""
 from datetime import datetime
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Optional
 
 from .const import API_V2_BASE
 from .util import raise_on_invalid_argument
@@ -24,6 +24,7 @@ class Water:  # pylint: disable=too-few-public-methods
         start: datetime,
         end: datetime,
         interval: str = INTERVAL_HOURLY,
+        device_mac_address: Optional[str] = None,
     ) -> dict:
         """Return user account data.
 
@@ -33,19 +34,25 @@ class Water:  # pylint: disable=too-few-public-methods
         :type start: ``datetime.datetime``
         :param end: The end datetime of the range to examine
         :type end: ``datetime.datetime``
+        :param device_mac_address: Limit results to a single device at the location
+        :type device_mac_address: ``Optional[str]``
         :rtype: ``dict``
         """
         raise_on_invalid_argument(interval, INTERVALS)
 
+        params = {
+            "endDate": end.isoformat(),
+            "interval": interval,
+            "locationId": location_id,
+            "startDate": start.isoformat(),
+        }
+        if device_mac_address:
+            params["macAddress"] = device_mac_address.replace(":", "")
+
         return await self._request(
             "get",
             f"{API_V2_BASE}/water/consumption",
-            params={
-                "endDate": end.isoformat(),
-                "interval": interval,
-                "locationId": location_id,
-                "startDate": start.isoformat(),
-            },
+            params=params,
         )
 
     async def get_metrics(

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -28,6 +28,9 @@ async def main() -> None:
             location_info = await api.location.get_info(first_location_id)
             _LOGGER.info(location_info)
 
+            first_device = location_info["devices"][0]
+            first_device_id = first_device["id"]
+
             consumption_info = await api.water.get_consumption_info(
                 first_location_id,
                 datetime(2020, 1, 16, 0, 0),
@@ -35,7 +38,14 @@ async def main() -> None:
             )
             _LOGGER.info(consumption_info)
 
-            first_device_id = location_info["devices"][0]["id"]
+            device_consumption = await api.water.get_consumption_info(
+                first_location_id,
+                datetime(2020, 1, 16, 0, 0),
+                datetime(2020, 1, 16, 23, 59, 59, 999000),
+                device_mac_address=first_device["macAddress"],
+            )
+            _LOGGER.info(device_consumption)
+
             device_info = await api.device.get_info(first_device_id)
             _LOGGER.info(device_info)
 

--- a/tests/test_water.py
+++ b/tests/test_water.py
@@ -34,6 +34,14 @@ async def test_get_consumption_info(aresponses, auth_success_response):
             text=load_fixture("water_consumption_info_response.json"), status=200
         ),
     )
+    aresponses.add(
+        "api-gw.meetflo.com",
+        "/api/v2/water/consumption",
+        "get",
+        aresponses.Response(
+            text=load_fixture("water_consumption_info_response.json"), status=200
+        ),
+    )
 
     start = datetime(2020, 1, 16, 0, 0)
     end = datetime(2020, 1, 16, 23, 59, 59, 999000)
@@ -42,6 +50,11 @@ async def test_get_consumption_info(aresponses, auth_success_response):
         api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
         consumption_info = await api.water.get_consumption_info(
             TEST_LOCATION_ID, start, end
+        )
+        assert len(consumption_info["items"]) == 5
+
+        consumption_info = await api.water.get_consumption_info(
+            TEST_LOCATION_ID, start, end, device_mac_address=TEST_MAC_ADDRESS
         )
         assert len(consumption_info["items"]) == 5
 


### PR DESCRIPTION
Closes #69
Supersedes #70

## What this does

The `/api/v2/water/consumption` endpoint accepts a `macAddress` query parameter to scope results to a single device, same as `/water/metrics`. Today `get_consumption_info` only sends `locationId`, so locations with multiple Flo devices can only get the location-wide aggregate (which shows incorrect data, e.g. in the Home Assistant integration).

This adds an optional `device_mac_address` parameter to `get_consumption_info`, sent as `macAddress` with `:` separators stripped, matching how `get_metrics` handles MACs. Omitting it preserves the existing behavior, so the change is backwards compatible.

```python
location_info = await api.location.get_info(location_id)
for device in location_info["devices"]:
    consumption = await api.water.get_consumption_info(
        location_id, start, end, device_mac_address=device["macAddress"]
    )
```

## Also included

While running the test suite I hit a latent bug in `API._request`: `resp.json()` ran before `raise_for_status()`, so non-JSON error bodies (plain-text or HTML error pages) escaped as raw `JSONDecodeError` instead of being wrapped in `RequestError`. Swapped the order so HTTP errors are always raised as `RequestError`. This also fixes `test_system_modes`, which was failing because of it.

CI on `dev` was already red: flake8's pre-commit repo is still on GitLab (fetch now requires auth), and the coverage/lint jobs used `python-version: 3.x` which is now 3.14 and cannot run the pinned pytest 6.2.5. This PR points flake8 at GitHub and pins those jobs to 3.11.

## Testing

- Extended `test_get_consumption_info` to cover the per-device call
- Full suite passes: 15 passed

## Checklist

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [x] Add yourself to `AUTHORS.md`.
