### PR TITLE
Bump version to 2026.09.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ use_parentheses = true
 
 [tool.poetry]
 name = "aioflo"
-version = "2021.11.0"
+version = "2026.09.0"
 description = "A Python3, async-friendly library for Flo by Moen Smart Water Detectors"
 readme = "README.md"
 authors = ["Aaron Bach <bachya1208@gmail.com>"]


### PR DESCRIPTION
Release 2026.09.0.

Includes:

- Optional `device_mac_address` on `get_consumption_info` (#74)
- HTTP status checked before JSON parse in `_request` (#74)
- Opt-in Moen SSO (Cognito) auth with token refresh (#75)
- CI unbreak for current GitHub-hosted runners (#74)

Version bump only. After merge, tag `2026.09.0` and merge `dev` into `main` to trigger PyPI publish.
