### PR TITLE
Add support for querying Flo Detect events

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ async def main() -> None:
         datetime(2020, 1, 16, 23, 59, 59, 999000),
     )
 
+    # Get recent Flo Detect water-flow events (near-real-time usage):
+    events = await api.flodetect.get_events(
+        first_device["macAddress"],
+        to=datetime(2026, 7, 12, 10, 25, 4),
+        limit=20,
+    )
+
     # Set the device in "Away" mode:
     await set_mode_away(a_location_id)
 
@@ -179,6 +186,13 @@ async def main() -> None:
             first_device["macAddress"],
             datetime(2020, 1, 16, 0, 0),
             datetime(2020, 1, 16, 23, 59, 59, 999000),
+        )
+
+        # Get recent Flo Detect water-flow events (near-real-time usage):
+        events = await api.flodetect.get_events(
+            first_device["macAddress"],
+            to=datetime(2026, 7, 12, 10, 25, 4),
+            limit=20,
         )
 
         # Set the device in "Away" mode:

--- a/aioflo/api.py
+++ b/aioflo/api.py
@@ -11,6 +11,7 @@ from .alarm import Alarm
 from .const import API_V2_BASE
 from .device import Device
 from .errors import RequestError
+from .flodetect import Flodetect
 from .location import Location
 from .presence import Presence
 from .user import User
@@ -73,6 +74,7 @@ class API:  # pylint: disable=too-few-public-methods,too-many-instance-attribute
         self.water: Water = Water(self._request)
         self.device: Device = Device(self._request)
         self.presence: Presence = Presence(self._request)
+        self.flodetect: Flodetect = Flodetect(self._request)
 
         # These endpoints will get instantiated post-authentication:
         self.user: Optional[User] = None

--- a/aioflo/flodetect.py
+++ b/aioflo/flodetect.py
@@ -1,0 +1,42 @@
+"""Define /flodetect endpoints."""
+from datetime import datetime
+from typing import Awaitable, Callable, Optional
+
+from .const import API_V2_BASE
+
+
+class Flodetect:  # pylint: disable=too-few-public-methods
+    """Define an object to handle the endpoints."""
+
+    def __init__(self, request: Callable[..., Awaitable]) -> None:
+        """Initialize."""
+        self._request: Callable[..., Awaitable] = request
+
+    async def get_events(
+        self,
+        device_mac_address: str,
+        *,
+        to: Optional[datetime] = None,
+        limit: Optional[int] = None,
+    ) -> dict:
+        """Return Flo Detect water-flow events for a device.
+
+        :param device_mac_address: MAC address of the Flo device
+        :type device_mac_address: ``str``
+        :param to: Return events at or before this datetime
+        :type to: ``Optional[datetime.datetime]``
+        :param limit: Maximum number of events to return
+        :type limit: ``Optional[int]``
+        :rtype: ``dict``
+        """
+        params = {"macAddress": device_mac_address.replace(":", "")}
+        if to is not None:
+            params["to"] = to.isoformat()
+        if limit is not None:
+            params["limit"] = str(limit)
+
+        return await self._request(
+            "get",
+            f"{API_V2_BASE}/flodetect/events",
+            params=params,
+        )

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -46,6 +46,13 @@ async def main() -> None:
             )
             _LOGGER.info(device_consumption)
 
+            events = await api.flodetect.get_events(
+                first_device["macAddress"],
+                to=datetime.now(),
+                limit=20,
+            )
+            _LOGGER.info(events)
+
             device_info = await api.device.get_info(first_device_id)
             _LOGGER.info(device_info)
 

--- a/tests/fixtures/flodetect_events_response.json
+++ b/tests/fixtures/flodetect_events_response.json
@@ -1,0 +1,27 @@
+{
+  "params": {
+    "macAddress": "123456abcdef",
+    "to": "2026-07-12T10:25:04-04:00",
+    "limit": "20"
+  },
+  "items": [
+    {
+      "id": "evt-001",
+      "macAddress": "123456abcdef",
+      "startTime": "2026-07-12T10:12:03-04:00",
+      "endTime": "2026-07-12T10:14:41-04:00",
+      "gallonsConsumed": 2.35,
+      "durationSeconds": 158,
+      "fixtureType": "faucet"
+    },
+    {
+      "id": "evt-002",
+      "macAddress": "123456abcdef",
+      "startTime": "2026-07-12T09:41:10-04:00",
+      "endTime": "2026-07-12T09:48:22-04:00",
+      "gallonsConsumed": 14.8,
+      "durationSeconds": 432,
+      "fixtureType": "shower"
+    }
+  ]
+}

--- a/tests/test_flodetect.py
+++ b/tests/test_flodetect.py
@@ -1,0 +1,59 @@
+"""Define tests for Flo Detect-related endpoints."""
+from datetime import datetime
+import json
+
+import aiohttp
+import pytest
+
+from aioflo import async_get_api
+
+from .common import TEST_EMAIL_ADDRESS, TEST_MAC_ADDRESS, TEST_PASSWORD, load_fixture
+
+
+@pytest.mark.asyncio
+async def test_get_events(aresponses, auth_success_response):
+    """Test successfully retrieving Flo Detect events."""
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_response), status=200),
+    )
+
+    queries = []
+
+    async def events_handler(request):
+        queries.append(dict(request.query))
+        return aresponses.Response(
+            text=load_fixture("flodetect_events_response.json"), status=200
+        )
+
+    aresponses.add(
+        "api-gw.meetflo.com", "/api/v2/flodetect/events", "get", events_handler
+    )
+    aresponses.add(
+        "api-gw.meetflo.com", "/api/v2/flodetect/events", "get", events_handler
+    )
+
+    to = datetime(2026, 7, 12, 10, 25, 4)
+
+    async with aiohttp.ClientSession() as session:
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
+
+        events = await api.flodetect.get_events(TEST_MAC_ADDRESS)
+        assert len(events["items"]) == 2
+        assert events["items"][0]["gallonsConsumed"] == 2.35
+        assert events["items"][0]["fixtureType"] == "faucet"
+        assert queries[0] == {"macAddress": TEST_MAC_ADDRESS.replace(":", "")}
+
+        events = await api.flodetect.get_events(
+            TEST_MAC_ADDRESS,
+            to=to,
+            limit=20,
+        )
+        assert len(events["items"]) == 2
+        assert queries[1] == {
+            "macAddress": TEST_MAC_ADDRESS.replace(":", ""),
+            "to": to.isoformat(),
+            "limit": "20",
+        }


### PR DESCRIPTION
**Describe what the PR does:**

Adds `api.flodetect.get_events()` for `GET /api/v2/flodetect/events`. That endpoint returns recent water-flow events for a device, which are closer to real-time than the daily consumption aggregates (the Home Assistant Flo integration currently lags ~15 minutes).

```python
events = await api.flodetect.get_events(
    first_device["macAddress"],
    to=datetime(2026, 7, 12, 10, 25, 4),
    limit=20,
)
```

`to` and `limit` are optional keyword-only filters. Colons are stripped from the MAC, matching `get_metrics`.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/aioflo/issues/72

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [x] Add yourself to `AUTHORS.md`.