### PR TITLE
Bump version to 2026.09.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ use_parentheses = true
 
 [tool.poetry]
 name = "aioflo"
-version = "2026.09.0"
+version = "2026.09.1"
 description = "A Python3, async-friendly library for Flo by Moen Smart Water Detectors"
 readme = "README.md"
 authors = ["Aaron Bach <bachya1208@gmail.com>"]


### PR DESCRIPTION
Release 2026.09.1.

Includes Flo Detect event support (`api.flodetect.get_events`) from #79 / #72.

After merge: tag `2026.09.1` and merge `dev` into `main` to publish to PyPI.
