### PR TITLE
Clean up leftover copy-paste and refresh CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-source = aionotion
+source = aioflo

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 **Does this fix a specific issue?**
 
-Fixes https://github.com/bachya/aioambient/issues/<ISSUE ID>
+Fixes https://github.com/bachya/aioflo/issues/<ISSUE ID>
 
 **Checklist:**
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,12 +5,12 @@ on:
   pull_request:
     branches:
       - dev
-      - master
+      - main
 
   push:
     branches:
       - dev
-      - master
+      - main
 
 jobs:
   test:
@@ -24,19 +24,21 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
 
       - run: |
           python -m venv venv
           venv/bin/pip install -r requirements_test.txt
-          venv/bin/py.test tests/
+          venv/bin/pytest tests/
 
   coverage:
 
@@ -45,24 +47,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
-          architecture: x64
+          python-version: "3.13"
 
       - run: |
           python -m venv venv
           venv/bin/pip install -r requirements_test.txt
-          venv/bin/py.test \
+          venv/bin/pytest \
             -s \
             --verbose \
             --cov-report term-missing \
             --cov-report xml \
             --cov=aioflo tests
 
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -73,13 +74,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
-          architecture: x64
+          python-version: "3.13"
 
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
         env:
           SKIP: no-commit-to-branch

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: "3.13"
 
       - name: Publish to PyPI
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.4
+    rev: 1.9.4
     hooks:
       - id: bandit
         args:
@@ -12,24 +12,25 @@ repos:
           - pbr
         files: ^aioflo/.+\.py$
   - repo: https://github.com/python/black
-    rev: 22.10.0
+    rev: 26.5.1
     hooks:
       - id: black
         args:
           - --safe
           - --quiet
         language_version: python3
-        files: ^((aioflo|tests)/.+)?[^/]+\.py$
+        files: ^((aioflo|examples|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         args:
           - --skip="./.*,*.json"
           - --quiet-level=4
+          - --ignore-words-list=thirdparty
         exclude_types: [json]
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 7.3.0
     hooks:
       - id: flake8
         additional_dependencies:
@@ -38,19 +39,19 @@ repos:
           - pydocstyle
         files: ^aioflo/.+\.py$
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 9.0.1
     hooks:
       - id: isort
         additional_dependencies:
           - toml
-        files: ^(aioflo|tests)/.+\.py$
+        files: ^(aioflo|examples|tests)/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v2.3.1
     hooks:
       - id: mypy
         files: ^aioflo/.+\.py$
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v6.0.0
     hooks:
       - id: check-json
       - id: check-yaml
@@ -58,19 +59,21 @@ repos:
       - id: no-commit-to-branch
         args:
           - --branch=dev
-          - --branch=master
+          - --branch=main
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
-        files: ^((aioflo|tests)/.+)?[^/]+\.py$
+        files: ^((aioflo|examples|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.17
+    rev: v0.1.30
     hooks:
       - id: shellcheck
         files: ^script/.+
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.1.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
+        args:
+          - --py39-plus

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+1. [Check for open features/bugs](https://github.com/bachya/aioflo/issues)
+   or [initiate a discussion on one](https://github.com/bachya/aioflo/issues/new).
+2. [Fork the repository](https://github.com/bachya/aioflo/fork).
+3. (_optional, but highly recommended_) Create a virtual environment: `python3 -m venv .venv`
+4. (_optional, but highly recommended_) Enter the virtual environment: `source ./.venv/bin/activate`
+5. Install the dev environment: `script/setup`
+6. Code your new feature or bug fix.
+7. Write tests that cover your new functionality.
+8. Run tests and ensure 100% code coverage: `script/test`
+9. Update `README.md` with any new documentation.
+10. Add yourself to `AUTHORS.md`.
+11. Submit a pull request!

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2023 Aaron Bach
+Copyright (c) 2020-2026 Aaron Bach
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@
 * Python 3.9
 * Python 3.10
 * Python 3.11
+* Python 3.12
+* Python 3.13
+* Python 3.14
 
 # Installation
 
-```python
+```bash
 pip install aioflo
 ```
 
@@ -32,8 +35,6 @@ pip install aioflo
 ```python
 import asyncio
 from datetime import datetime
-
-from aiohttp import ClientSession
 
 from aioflo import async_get_api
 
@@ -53,6 +54,9 @@ async def main() -> None:
     first_device = location_info["devices"][0]
     first_device_id = first_device["id"]
     device_info = await api.device.get_info(first_device_id)
+
+    # Get all alarms:
+    alarms = await api.alarm.get_all()
 
     # Run a health test
     health_test_response = await api.device.run_health_test(first_device_id)
@@ -94,32 +98,17 @@ async def main() -> None:
     )
 
     # Set the device in "Away" mode:
-    await set_mode_away(a_location_id)
+    await api.location.set_mode_away(a_location_id)
 
     # Set the device in "Home" mode:
-    await set_mode_home(a_location_id)
+    await api.location.set_mode_home(a_location_id)
 
     # Set the device in "Sleep" mode for 120 minutes, then return to "Away" mode:
-    await set_mode_sleep(a_location_id, 120, "away")
+    await api.location.set_mode_sleep(a_location_id, 120, "away")
 
 
 asyncio.run(main())
 ```
-
-## Moen SSO (Cognito) auth
-
-The current Moen Smartwater app authenticates against Moen's SSO endpoint rather than the
-legacy Flo `users/auth` flow. `use_sso=True` opts into it: the access token is sent to
-`api-gw.meetflo.com` as a bearer token and is refreshed on expiry and on a `401`, falling
-back to a full login if the refresh token is rejected.
-
-```python
-api = await async_get_api("<EMAIL>", "<PASSWORD>", use_sso=True)
-```
-
-The legacy flow is the default and is unchanged. The legacy endpoint still works, so this
-is cover for it being retired rather than a fix for a current failure.
-
 
 By default, the library creates a new connection to Flo with each coroutine. If you are
 calling a large number of coroutines (or merely want to squeeze out every second of
@@ -155,6 +144,9 @@ async def main() -> None:
         first_device = location_info["devices"][0]
         first_device_id = first_device["id"]
         device_info = await api.device.get_info(first_device_id)
+
+        # Get all alarms:
+        alarms = await api.alarm.get_all()
 
         # Run a health test
         health_test_response = await api.device.run_health_test(first_device_id)
@@ -196,29 +188,28 @@ async def main() -> None:
         )
 
         # Set the device in "Away" mode:
-        await set_mode_away(a_location_id)
+        await api.location.set_mode_away(a_location_id)
 
         # Set the device in "Home" mode:
-        await set_mode_home(a_location_id)
+        await api.location.set_mode_home(a_location_id)
 
         # Set the device in "Sleep" mode for 120 minutes, then return to "Away" mode:
-        await set_mode_sleep(a_location_id, 120, "away")
+        await api.location.set_mode_sleep(a_location_id, 120, "away")
 
 
 asyncio.run(main())
 ```
 
-# Contributing
+## Moen SSO (Cognito) auth
 
-1. [Check for open features/bugs](https://github.com/bachya/aioflo/issues)
-  or [initiate a discussion on one](https://github.com/bachya/aioflo/issues/new).
-2. [Fork the repository](https://github.com/bachya/aioflo/fork).
-3. (_optional, but highly recommended_) Create a virtual environment: `python3 -m venv .venv`
-4. (_optional, but highly recommended_) Enter the virtual environment: `source ./.venv/bin/activate`
-5. Install the dev environment: `script/setup`
-6. Code your new feature or bug fix.
-7. Write tests that cover your new functionality.
-8. Run tests and ensure 100% code coverage: `script/test`
-9. Update `README.md` with any new documentation.
-10. Add yourself to `AUTHORS.md`.
-11. Submit a pull request!
+The current Moen Smartwater app authenticates against Moen's SSO endpoint rather than the
+legacy Flo `users/auth` flow. `use_sso=True` opts into it: the access token is sent to
+`api-gw.meetflo.com` as a bearer token and is refreshed on expiry and on a `401`, falling
+back to a full login if the refresh token is rejected.
+
+```python
+api = await async_get_api("<EMAIL>", "<PASSWORD>", use_sso=True)
+```
+
+The legacy flow is the default and is unchanged. The legacy endpoint still works, so this
+is cover for it being retired rather than a fix for a current failure.

--- a/aioflo/__init__.py
+++ b/aioflo/__init__.py
@@ -1,2 +1,3 @@
 """Define the aioflo package."""
+
 from .api import async_get_api  # noqa

--- a/aioflo/alarm.py
+++ b/aioflo/alarm.py
@@ -1,5 +1,7 @@
 """Define /alarms endpoints."""
-from typing import Awaitable, Callable
+
+from collections.abc import Awaitable
+from typing import Callable
 
 from .const import API_V2_BASE
 
@@ -11,6 +13,6 @@ class Alarm:  # pylint: disable=too-few-public-methods
         """Initialize."""
         self._request: Callable[..., Awaitable] = request
 
-    async def get_all(self):
+    async def get_all(self) -> dict:
         """Get all alarms."""
         return await self._request("get", f"{API_V2_BASE}/alarms")

--- a/aioflo/api.py
+++ b/aioflo/api.py
@@ -1,4 +1,5 @@
 """Define a base client for interacting with Flo."""
+
 from datetime import datetime, timedelta
 import logging
 from typing import Optional
@@ -250,8 +251,8 @@ async def async_get_api(
 
     :param session: An ``aiohttp`` ``ClientSession``
     :type session: ``aiohttp.client.ClientSession``
-    :param email: A Flo email address
-    :type email: ``str``
+    :param username: A Flo email address
+    :type username: ``str``
     :param password: A Flo password
     :type password: ``str``
     :param use_sso: Use the Moen SSO (Cognito) auth flow instead of the legacy one

--- a/aioflo/const.py
+++ b/aioflo/const.py
@@ -1,2 +1,3 @@
 """Define package constants."""
+
 API_V2_BASE: str = "https://api-gw.meetflo.com/api/v2"

--- a/aioflo/device.py
+++ b/aioflo/device.py
@@ -1,5 +1,7 @@
 """Define /device endpoints."""
-from typing import Awaitable, Callable
+
+from collections.abc import Awaitable
+from typing import Callable
 
 from .const import API_V2_BASE
 
@@ -20,7 +22,7 @@ class Device:  # pylint: disable=too-few-public-methods
         """
         return await self._request("get", f"{API_V2_BASE}/devices/{device_id}")
 
-    async def run_health_test(self, device_id: str) -> None:
+    async def run_health_test(self, device_id: str) -> dict:
         """Run a health test for a specific device.
 
         :param device_id: Unique identifier for the device
@@ -31,7 +33,7 @@ class Device:  # pylint: disable=too-few-public-methods
             "post", f"{API_V2_BASE}/devices/{device_id}/healthTest/run"
         )
 
-    async def open_valve(self, device_id: str) -> None:
+    async def open_valve(self, device_id: str) -> dict:
         """Open the valve for a specific device.
 
         :param device_id: Unique identifier for the device
@@ -44,7 +46,7 @@ class Device:  # pylint: disable=too-few-public-methods
             json={"valve": {"target": "open"}},
         )
 
-    async def close_valve(self, device_id: str) -> None:
+    async def close_valve(self, device_id: str) -> dict:
         """Close the valve for a specific device.
 
         :param device_id: Unique identifier for the device

--- a/aioflo/flodetect.py
+++ b/aioflo/flodetect.py
@@ -1,6 +1,8 @@
 """Define /flodetect endpoints."""
+
+from collections.abc import Awaitable
 from datetime import datetime
-from typing import Awaitable, Callable, Optional
+from typing import Callable, Optional
 
 from .const import API_V2_BASE
 

--- a/aioflo/location.py
+++ b/aioflo/location.py
@@ -1,5 +1,7 @@
 """Define /location endpoints."""
-from typing import Awaitable, Callable, Optional
+
+from collections.abc import Awaitable
+from typing import Callable, Optional
 
 from .const import API_V2_BASE
 from .util import raise_on_invalid_argument
@@ -40,7 +42,7 @@ class Location:
         location_id: str,
         include_device_info: bool = False,
     ) -> dict:
-        """Return user account data.
+        """Return location data.
 
         :param location_id: A Flo location UUID
         :type location_id: ``str``
@@ -82,7 +84,7 @@ class Location:
         revert_minutes: int,
         revert_mode: Optional[str] = SYSTEM_MODE_HOME,
     ) -> None:
-        """Set the system mode to "Home".
+        """Set the system mode to "Sleep".
 
         :param location_id: A Flo location UUID
         :type location_id: ``str``

--- a/aioflo/presence.py
+++ b/aioflo/presence.py
@@ -1,5 +1,7 @@
 """Define /presence endpoints."""
-from typing import Awaitable, Callable
+
+from collections.abc import Awaitable
+from typing import Callable
 
 from .const import API_V2_BASE
 

--- a/aioflo/user.py
+++ b/aioflo/user.py
@@ -1,5 +1,7 @@
 """Define /user endpoints."""
-from typing import Awaitable, Callable
+
+from collections.abc import Awaitable
+from typing import Callable
 
 from .const import API_V2_BASE
 

--- a/aioflo/util/__init__.py
+++ b/aioflo/util/__init__.py
@@ -1,9 +1,10 @@
 """Define general utilities."""
+
 from ..errors import RequestError
 
 
 def raise_on_invalid_argument(value, options):
-    """Raise a RequestError when an invalid consumption interval is provided."""
+    """Raise a RequestError when a value is not one of the allowed options."""
     if value not in options:
         raise RequestError(
             f"Invalid keyword argument: {value} (valid options: {options})"

--- a/aioflo/water.py
+++ b/aioflo/water.py
@@ -1,6 +1,8 @@
 """Define /water endpoints."""
+
+from collections.abc import Awaitable
 from datetime import datetime
-from typing import Awaitable, Callable, Optional
+from typing import Callable, Optional
 
 from .const import API_V2_BASE
 from .util import raise_on_invalid_argument
@@ -26,7 +28,7 @@ class Water:  # pylint: disable=too-few-public-methods
         interval: str = INTERVAL_HOURLY,
         device_mac_address: Optional[str] = None,
     ) -> dict:
-        """Return user account data.
+        """Return water consumption data.
 
         :param location_id: A Flo location UUID
         :type location_id: ``str``
@@ -34,6 +36,8 @@ class Water:  # pylint: disable=too-few-public-methods
         :type start: ``datetime.datetime``
         :param end: The end datetime of the range to examine
         :type end: ``datetime.datetime``
+        :param interval: Aggregation interval (``1h``, ``1d``, or ``1m``)
+        :type interval: ``str``
         :param device_mac_address: Limit results to a single device at the location
         :type device_mac_address: ``Optional[str]``
         :rtype: ``dict``
@@ -62,12 +66,16 @@ class Water:  # pylint: disable=too-few-public-methods
         end: datetime,
         interval: str = INTERVAL_HOURLY,
     ) -> dict:
-        """Return user account data.
+        """Return water usage metrics for a device.
 
+        :param device_mac_address: MAC address of the Flo device
+        :type device_mac_address: ``str``
         :param start: The start datetime of the range to examine
         :type start: ``datetime.datetime``
         :param end: The end datetime of the range to examine
         :type end: ``datetime.datetime``
+        :param interval: Aggregation interval (``1h``, ``1d``, or ``1m``)
+        :type interval: ``str``
         :rtype: ``dict``
         """
         raise_on_invalid_argument(interval, INTERVALS)

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -1,4 +1,5 @@
 """Run an example script to quickly test."""
+
 import asyncio
 from datetime import datetime
 import logging
@@ -12,6 +13,8 @@ _LOGGER = logging.getLogger()
 
 EMAIL = "<EMAIL>"
 PASSWORD = "<PASSWORD>"
+# The current Moen Smartwater app uses SSO; set True if the legacy login fails:
+USE_SSO = False
 
 
 async def main() -> None:
@@ -19,7 +22,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     async with ClientSession() as session:
         try:
-            api = await async_get_api(EMAIL, PASSWORD, session=session)
+            api = await async_get_api(EMAIL, PASSWORD, session=session, use_sso=USE_SSO)
 
             user_info = await api.user.get_info()
             _LOGGER.info(user_info)
@@ -30,6 +33,9 @@ async def main() -> None:
 
             first_device = location_info["devices"][0]
             first_device_id = first_device["id"]
+
+            alarm_info = await api.alarm.get_all()
+            _LOGGER.info(alarm_info)
 
             consumption_info = await api.water.get_consumption_info(
                 first_location_id,
@@ -45,6 +51,13 @@ async def main() -> None:
                 device_mac_address=first_device["macAddress"],
             )
             _LOGGER.info(device_consumption)
+
+            metrics = await api.water.get_metrics(
+                first_device["macAddress"],
+                datetime(2020, 1, 16, 0, 0),
+                datetime(2020, 1, 16, 23, 59, 59, 999000),
+            )
+            _LOGGER.info(metrics)
 
             events = await api.flodetect.get_events(
                 first_device["macAddress"],
@@ -67,6 +80,8 @@ async def main() -> None:
 
             ping_response = await api.presence.ping()
             _LOGGER.info(ping_response)
+
+            await api.location.set_mode_home(first_location_id)
 
         except FloError as err:
             _LOGGER.error("There was an error: %s", err)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ indent = "    "
 known_first_party = "aioflo,examples,tests"
 line_length = 88
 multi_line_output = 3
-not_skip = "__init__.py"
-sections = "FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
+sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
 use_parentheses = true
 
 [tool.poetry]
@@ -32,6 +31,9 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -42,7 +44,7 @@ python = ">=3.9.0"
 
 [tool.poetry.dev-dependencies]
 aresponses = "^2.0.0"
-pre-commit = "^2.15.0"
+pre-commit = "^4.0.0"
 pytest = "^7.0.0"
 pytest-asyncio = "^0.19.0"
 pytest-cov = "^3.0.0"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.8.0
-aresponses==2.0.0
-pytest-aiohttp==0.3.0
-pytest-cov==2.8.1
-pytest==6.2.5
+aresponses>=2.0.0
+pytest>=7.0.0
+pytest-asyncio>=0.19.0
+pytest-cov>=3.0.0

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,5 @@
 """Define common test utilities."""
+
 import os
 
 TEST_ACCOUNT_ID = "aabbccdd"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Define fixtures available for all tests."""
+
 import time
 
 import pytest

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -1,4 +1,5 @@
 """Define tests for alarm-related endpoints."""
+
 import json
 
 import aiohttp

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 """Define general tests for the API."""
+
 # pylint: disable=protected-access
 from datetime import datetime, timedelta
 import json
@@ -69,9 +70,7 @@ async def test_expired_api_token(aresponses, auth_success_response, caplog):
 
     async with aiohttp.ClientSession() as session:
         api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
-        print(api._token_expiration)
         api._token_expiration = datetime.now() - timedelta(days=1)
-        print(api._token_expiration)
         await api._request("get", "https://api.meetflo.com/api/v1/random_good_endpoint")
         assert any("Requesting new access token" in e.message for e in caplog.records)
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,4 +1,5 @@
 """Define tests for device-related endpoints."""
+
 import json
 
 import aiohttp

--- a/tests/test_flodetect.py
+++ b/tests/test_flodetect.py
@@ -1,4 +1,5 @@
 """Define tests for Flo Detect-related endpoints."""
+
 from datetime import datetime
 import json
 

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -1,4 +1,5 @@
 """Define tests for location-related endpoints."""
+
 import json
 
 import aiohttp

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -1,4 +1,5 @@
 """Define tests for user-related endpoints."""
+
 import json
 
 import aiohttp

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,4 +1,5 @@
 """Define tests for user-related endpoints."""
+
 import json
 
 import aiohttp

--- a/tests/test_water.py
+++ b/tests/test_water.py
@@ -1,4 +1,5 @@
 """Define tests for water-related endpoints."""
+
 from datetime import datetime
 import json
 


### PR DESCRIPTION
**Describe what the PR does:**

Housekeeping after the 2026.09.x releases:

- Move contributing steps out of `README.md` into `CONTRIBUTING.md`
- Fix copy-paste leftovers (`.coveragerc` pointed at aionotion, PR template linked to aioambient, README `set_mode_*` examples were not methods on `api.location`, copy-pasted docstrings)
- Finish the `master` → `main` rename in CI and pre-commit
- Document Python 3.12–3.14 and `api.alarm.get_all()`
- Refresh GitHub Actions, pre-commit pins, and `requirements_test.txt`
- Expand the example script with SSO, alarms, metrics, and home mode

**Does this fix a specific issue?**

No.

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [x] Add yourself to `AUTHORS.md`.