### PR TITLE
Bump version to 2026.09.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ use_parentheses = true
 
 [tool.poetry]
 name = "aioflo"
-version = "2026.09.1"
+version = "2026.09.2"
 description = "A Python3, async-friendly library for Flo by Moen Smart Water Detectors"
 readme = "README.md"
 authors = ["Aaron Bach <bachya1208@gmail.com>"]


### PR DESCRIPTION
Release 2026.09.2.

Includes dropping Python 3.9 and 3.10 (Python 3.11 is now the minimum), raising aiohttp / pytest / filelock floors, and README/CI cleanup from #82–#85.

After merge: tag `2026.09.2` and merge `dev` into `main` to publish to PyPI.