### PR TITLE
Parse Flo Detect events from the live payload shape

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+EMAIL=you@example.com
+PASSWORD=secret
+# Set true if legacy login fails (the current Moen Smartwater app uses SSO):
+USE_SSO=false
+# Optional: maximum events to request per device (default 20)
+# EVENT_LIMIT=20

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .mypy_cache
 .tox/
 .venv
+.env
 __pycache__/
 aioflo.egg-info
 coverage.xml

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ async def main() -> None:
         to=datetime(2026, 7, 12, 10, 25, 4),
         limit=20,
     )
+    # The payload groups events per device under items[].events. Flatten it:
+    flow_events = api.flodetect.parse_events(events)
+    # Each event has startAt, endAt, totalGal, duration, and predicted.displayText.
 
     # Set the device in "Away" mode:
     await api.location.set_mode_away(a_location_id)
@@ -175,6 +178,9 @@ async def main() -> None:
             to=datetime(2026, 7, 12, 10, 25, 4),
             limit=20,
         )
+        # The payload groups events per device under items[].events. Flatten it:
+        flow_events = api.flodetect.parse_events(events)
+        # Each event has startAt, endAt, totalGal, duration, and predicted.displayText.
 
         # Set the device in "Away" mode:
         await api.location.set_mode_away(a_location_id)

--- a/aioflo/flodetect.py
+++ b/aioflo/flodetect.py
@@ -13,6 +13,22 @@ class Flodetect:  # pylint: disable=too-few-public-methods
         """Initialize."""
         self._request: Callable[..., Awaitable] = request
 
+    @staticmethod
+    def parse_events(payload: dict) -> list[dict]:
+        """Flatten a /flodetect/events payload into a list of event dicts.
+
+        The live API groups events per device::
+
+            {"params": {...}, "items": [{"macAddress": "...", "events": [...]}]}
+
+        Each event uses ``startAt``, ``endAt``, ``totalGal``, ``duration``, and
+        ``predicted.displayText`` (not a flat ``items`` list of events).
+        """
+        events: list[dict] = []
+        for item in payload.get("items") or []:
+            events.extend(item.get("events") or [])
+        return events
+
     async def get_events(
         self,
         device_mac_address: str,
@@ -21,6 +37,9 @@ class Flodetect:  # pylint: disable=too-few-public-methods
         limit: int | None = None,
     ) -> dict:
         """Return Flo Detect water-flow events for a device.
+
+        The raw payload groups events per device under ``items[].events``.
+        Pass it to :meth:`parse_events` to get a flat list.
 
         :param device_mac_address: MAC address of the Flo device
         :type device_mac_address: ``str``

--- a/examples/test_events.py
+++ b/examples/test_events.py
@@ -1,0 +1,126 @@
+"""Fetch live Flo Detect events using credentials from a .env file."""
+
+import asyncio
+from datetime import datetime
+import json
+import logging
+import os
+from pathlib import Path
+import sys
+
+from aiohttp import ClientSession
+
+from aioflo import async_get_api
+from aioflo.errors import FloError
+
+_LOGGER = logging.getLogger()
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MISSING_CREDS = """\
+Missing EMAIL or PASSWORD. Create a .env in the repo root:
+
+  EMAIL=you@example.com
+  PASSWORD=secret
+  USE_SSO=true
+"""
+
+
+def _load_dotenv(path: Path) -> None:
+    """Load KEY=VALUE pairs from a .env file without overriding existing vars."""
+    if not path.is_file():
+        return
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :]
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        os.environ.setdefault(key, value)
+
+
+def _as_bool(value: str | None, default: bool = False) -> bool:
+    """Interpret a truthy environment string."""
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _summarize_event(event: dict) -> str:
+    """Return a one-line summary of a Flo Detect event."""
+    predicted = (event.get("predicted") or {}).get("displayText")
+    return (
+        f"{event.get('startAt')}  {predicted}  "
+        f"{event.get('totalGal')} gal  {event.get('duration')}s"
+    )
+
+
+async def main() -> None:
+    """Authenticate and print recent Flo Detect events for every device."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    for candidate in (
+        Path.cwd() / ".env",
+        _REPO_ROOT / ".env",
+        Path(__file__).resolve().parent / ".env",
+    ):
+        _load_dotenv(candidate)
+
+    email = os.environ.get("EMAIL")
+    password = os.environ.get("PASSWORD")
+    if not email or not password:
+        sys.stderr.write(_MISSING_CREDS)
+        raise SystemExit(1)
+
+    use_sso = _as_bool(os.environ.get("USE_SSO"))
+    limit = int(os.environ.get("EVENT_LIMIT", "20"))
+
+    async with ClientSession() as session:
+        try:
+            api = await async_get_api(email, password, session=session, use_sso=use_sso)
+
+            user_info = await api.user.get_info()
+            locations = user_info.get("locations") or []
+            if not locations:
+                _LOGGER.error("No locations on this account")
+                return
+
+            for location in locations:
+                location_id = location["id"]
+                location_info = await api.location.get_info(location_id)
+                loc_name = location_info.get("nickname") or location_id
+                devices = location_info.get("devices") or []
+                _LOGGER.info(
+                    "Location %s (%s): %s device(s)",
+                    loc_name,
+                    location_id,
+                    len(devices),
+                )
+
+                for device in devices:
+                    mac = device.get("macAddress")
+                    name = device.get("nickname") or mac
+                    if not mac:
+                        _LOGGER.warning("Skipping device without macAddress: %s", name)
+                        continue
+
+                    payload = await api.flodetect.get_events(
+                        mac,
+                        to=datetime.now(),
+                        limit=limit,
+                    )
+                    events = api.flodetect.parse_events(payload)
+                    _LOGGER.info("Events for %s (%s): %s", name, mac, len(events))
+                    _LOGGER.info(json.dumps(payload, indent=2))
+                    for event in events:
+                        _LOGGER.info("  %s", _summarize_event(event))
+
+        except FloError as err:
+            _LOGGER.error("There was an error: %s", err)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/fixtures/flodetect_events_response.json
+++ b/tests/fixtures/flodetect_events_response.json
@@ -1,27 +1,40 @@
 {
   "params": {
     "macAddress": "123456abcdef",
-    "to": "2026-07-12T10:25:04-04:00",
-    "limit": "20"
+    "from": "2026-08-04T03:49:00Z",
+    "to": "2026-09-04T03:49:43.611Z",
+    "tz": "America/Los_Angeles",
+    "minGallons": 0
   },
   "items": [
     {
-      "id": "evt-001",
       "macAddress": "123456abcdef",
-      "startTime": "2026-07-12T10:12:03-04:00",
-      "endTime": "2026-07-12T10:14:41-04:00",
-      "gallonsConsumed": 2.35,
-      "durationSeconds": 158,
-      "fixtureType": "faucet"
-    },
-    {
-      "id": "evt-002",
-      "macAddress": "123456abcdef",
-      "startTime": "2026-07-12T09:41:10-04:00",
-      "endTime": "2026-07-12T09:48:22-04:00",
-      "gallonsConsumed": 14.8,
-      "durationSeconds": 432,
-      "fixtureType": "shower"
+      "events": [
+        {
+          "id": "evt-001",
+          "startAt": "2026-07-12T10:12:03-04:00",
+          "endAt": "2026-07-12T10:14:41-04:00",
+          "totalGal": 2.35,
+          "duration": 158,
+          "macAddress": "123456abcdef",
+          "predicted": {
+            "id": 300,
+            "displayText": "Faucet"
+          }
+        },
+        {
+          "id": "evt-002",
+          "startAt": "2026-07-12T09:41:10-04:00",
+          "endAt": "2026-07-12T09:48:22-04:00",
+          "totalGal": 14.8,
+          "duration": 432,
+          "macAddress": "123456abcdef",
+          "predicted": {
+            "id": 101,
+            "displayText": "Shower"
+          }
+        }
+      ]
     }
   ]
 }

--- a/tests/test_flodetect.py
+++ b/tests/test_flodetect.py
@@ -7,6 +7,7 @@ import aiohttp
 import pytest
 
 from aioflo import async_get_api
+from aioflo.flodetect import Flodetect
 
 from .common import TEST_EMAIL_ADDRESS, TEST_MAC_ADDRESS, TEST_PASSWORD, load_fixture
 
@@ -42,9 +43,14 @@ async def test_get_events(aresponses, auth_success_response):
         api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
 
         events = await api.flodetect.get_events(TEST_MAC_ADDRESS)
-        assert len(events["items"]) == 2
-        assert events["items"][0]["gallonsConsumed"] == 2.35
-        assert events["items"][0]["fixtureType"] == "faucet"
+        assert len(events["items"]) == 1
+        parsed = api.flodetect.parse_events(events)
+        assert len(parsed) == 2
+        assert parsed[0]["totalGal"] == 2.35
+        assert parsed[0]["duration"] == 158
+        assert parsed[0]["startAt"] == "2026-07-12T10:12:03-04:00"
+        assert parsed[0]["predicted"]["displayText"] == "Faucet"
+        assert parsed[1]["predicted"]["displayText"] == "Shower"
         assert queries[0] == {"macAddress": TEST_MAC_ADDRESS.replace(":", "")}
 
         events = await api.flodetect.get_events(
@@ -52,9 +58,16 @@ async def test_get_events(aresponses, auth_success_response):
             to=to,
             limit=20,
         )
-        assert len(events["items"]) == 2
+        assert len(api.flodetect.parse_events(events)) == 2
         assert queries[1] == {
             "macAddress": TEST_MAC_ADDRESS.replace(":", ""),
             "to": to.isoformat(),
             "limit": "20",
         }
+
+
+def test_parse_events_empty_payloads():
+    """Test parse_events on missing or empty item groups."""
+    assert Flodetect.parse_events({}) == []
+    assert Flodetect.parse_events({"items": []}) == []
+    assert Flodetect.parse_events({"items": [{"macAddress": "123456abcdef"}]}) == []


### PR DESCRIPTION
**Describe what the PR does:**

A live call against `/api/v2/flodetect/events` showed the payload is grouped per device under `items[].events`, with `startAt`, `endAt`, `totalGal`, `duration`, and `predicted.displayText` — not a flat `items` list of events.

- Add `api.flodetect.parse_events()` to flatten that list
- Update the fixture and tests to the live shape
- Add a read-only `.env`-based live example (`examples/test_events.py`)

`get_events()` still returns the raw payload. This is a new helper, not a breaking change.

**Does this fix a specific issue?**

No.

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [x] Add yourself to `AUTHORS.md`.