### PR TITLE
Normalize the no-sensor water-temperature placeholder to None

### DIFF
--- a/aioflo/const.py
+++ b/aioflo/const.py
@@ -1,3 +1,9 @@
 """Define package constants."""
 
 API_V2_BASE: str = "https://api-gw.meetflo.com/api/v2"
+
+# Shutoff valves without a water-temperature sensor do not omit tempF from
+# telemetry; they report a fixed placeholder (225 on the units this was written
+# against). No domestic supply reaches boiling, so a reading at or above this is
+# a sentinel rather than a measurement.
+IMPLAUSIBLE_WATER_TEMP_F: float = 212.0

--- a/aioflo/device.py
+++ b/aioflo/device.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 
-from .const import API_V2_BASE
+from .const import API_V2_BASE, IMPLAUSIBLE_WATER_TEMP_F
 
 
 class Device:  # pylint: disable=too-few-public-methods
@@ -15,11 +15,18 @@ class Device:  # pylint: disable=too-few-public-methods
     async def get_info(self, device_id: str) -> dict:
         """Return device specific data.
 
+        `telemetry.current.tempF` is normalized to ``None`` when the device
+        reports the no-sensor placeholder; see :func:`_normalize_telemetry`.
+
         :param device_id: Unique identifier for the device
         :type device_id: ``str``
         :rtype: ``dict``
         """
-        return await self._request("get", f"{API_V2_BASE}/devices/{device_id}")
+        device_info = await self._request(
+            "get", f"{API_V2_BASE}/devices/{device_id}"
+        )
+        _normalize_telemetry(device_info)
+        return device_info
 
     async def run_health_test(self, device_id: str) -> dict:
         """Run a health test for a specific device.
@@ -57,3 +64,23 @@ class Device:  # pylint: disable=too-few-public-methods
             f"{API_V2_BASE}/devices/{device_id}",
             json={"valve": {"target": "closed"}},
         )
+
+
+def _normalize_telemetry(device_info: dict) -> None:
+    """Replace the no-sensor water-temperature placeholder with ``None``.
+
+    A shutoff valve with no water-temperature sensor does not omit ``tempF``,
+    it returns a constant placeholder (225 on the units this was written
+    against). Passed through, that is indistinguishable from a measurement:
+    consumers chart it, store it, and trigger on it.
+
+    The check is against boiling rather than the specific value observed, so it
+    does not depend on every unit using the same sentinel. Detectors report
+    ambient air temperature through the same field and cannot approach it.
+    """
+    current = (device_info.get("telemetry") or {}).get("current")
+    if not isinstance(current, dict):
+        return
+    temperature = current.get("tempF")
+    if isinstance(temperature, (int, float)) and temperature >= IMPLAUSIBLE_WATER_TEMP_F:
+        current["tempF"] = None

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -114,3 +114,65 @@ async def test_device_valve_close(aresponses, auth_success_response):
         assert device_info["nickname"] == "Smart Water Shutoff"
         assert device_info["valve"]["target"] == "closed"
         assert device_info["valve"]["lastKnown"] == "open"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("placeholder", [225, 212, 220, 300])
+async def test_get_device_info_normalizes_temperature_placeholder(
+    aresponses, auth_success_response, placeholder
+):
+    """A valve with no temperature sensor reports a placeholder, not a reading.
+
+    Parametrized across the boundary so the check cannot regress to special-casing
+    the one value observed in the wild (225).
+    """
+    device_info_payload = json.loads(load_fixture("device_info_response.json"))
+    device_info_payload["telemetry"]["current"]["tempF"] = placeholder
+
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_response), status=200),
+    )
+    aresponses.add(
+        "api-gw.meetflo.com",
+        "/api/v2/devices/98765",
+        "get",
+        aresponses.Response(text=json.dumps(device_info_payload), status=200),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
+        device_info = await api.device.get_info(TEST_DEVICE_ID)
+        assert device_info["telemetry"]["current"]["tempF"] is None
+        # Everything else in the block is untouched.
+        assert device_info["telemetry"]["current"]["psi"] == 54.20000076293945
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reading", [70, 211.9, 33])
+async def test_get_device_info_keeps_a_real_temperature(
+    aresponses, auth_success_response, reading
+):
+    """Anything below boiling is a measurement and is passed through unchanged."""
+    device_info_payload = json.loads(load_fixture("device_info_response.json"))
+    device_info_payload["telemetry"]["current"]["tempF"] = reading
+
+    aresponses.add(
+        "api.meetflo.com",
+        "/api/v1/users/auth",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_response), status=200),
+    )
+    aresponses.add(
+        "api-gw.meetflo.com",
+        "/api/v2/devices/98765",
+        "get",
+        aresponses.Response(text=json.dumps(device_info_payload), status=200),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = await async_get_api(TEST_EMAIL_ADDRESS, TEST_PASSWORD, session=session)
+        device_info = await api.device.get_info(TEST_DEVICE_ID)
+        assert device_info["telemetry"]["current"]["tempF"] == reading


### PR DESCRIPTION
### The problem

A Flo Smart Water Shutoff with no water-temperature sensor does not omit `tempF`
from telemetry, it returns a constant placeholder — 225 on the units I have
access to. `get_info` passes it through, so consumers cannot tell it from a
measurement. 225 °F is above the boiling point of water and far above anything a
domestic supply carries.

Recorder data from one valve over nine days:

| entity | rows | distinct values |
|---|---|---|
| water temperature | 70 | **2** — `225` (x60), `unavailable` (x10) |

Over the same window flow logged 19 distinct values and pressure 18, so the
device was reporting live data. It simply never measures a temperature.

Across 168 consecutive hourly buckets from `/water/metrics`, `averageTempF` was
`225` in 166 and `null` in 2, with no other value. It is also `225` in live
telemetry sampled at 15-second resolution during real water use, so it does not
vary with flow, time or usage.

### The change

`get_info` sets `telemetry.current.tempF` to `None` when it is at or above
boiling. Nothing else in the block is modified.

The threshold is boiling rather than 225 so the check does not depend on every
unit using the same sentinel. Detectors report ambient air temperature through
the same field and cannot approach it.

### Why here rather than downstream

Home Assistant's `flo` integration publishes this value as a
`SensorDeviceClass.TEMPERATURE` with `SensorStateClass.MEASUREMENT`, so it lands
in long-term statistics. I opened home-assistant/core#182004 to filter it there
and the review asked for it in the library instead, which is the right call:
every `aioflo` consumer has the same problem, and this is a protocol quirk rather
than a presentation choice.

Related: home-assistant/core#180671.

### Tests

Parametrized across the boundary — 225, 212, 220 and 300 are suppressed; 70,
211.9 and 33 pass through unchanged. Full suite passes (35).
